### PR TITLE
resolved issue where fining beam caused apple to disappear

### DIFF
--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -63,6 +63,7 @@ class HarvestEnv(MapEnv):
         self.apple_points = []
         self.wall_points = []
         self.firing_points = []
+        self.hidden_apples = []
         for row in range(self.base_map.shape[0]):
             for col in range(self.base_map.shape[1]):
                 if self.base_map[row, col] == 'P':
@@ -213,11 +214,15 @@ class HarvestEnv(MapEnv):
             agent_pos.append(agent.get_pos().tolist())
         for i in range(len(self.firing_points)):
             row, col = self.firing_points[i]
-            if [row, col] not in agent_pos:
-                self.map[row, col] = ' '
-            else:
+            if self.firing_points[i] in self.hidden_apples:
+                self.map[row, col] = 'A'
+            elif [row, col] in agent_pos:
                 # put the agent back if they were temporarily obscured by the firing beam
                 self.map[row, col] = 'P'
+            else:
+                self.map[row, col] = ' '
+        self.hidden_apples = []
+        self.firing_points = []
 
     def spawn_apples(self):
         # iterate over the spawn points in self.ascii_map and compare it with
@@ -276,6 +281,8 @@ class HarvestEnv(MapEnv):
         for i in range(num_fire_cells):
             next_cell = start_pos + firing_direction
             if self.test_if_in_bounds(next_cell) and self.map[next_cell[0], next_cell[1]] != '@':
+                if self.map[next_cell[0], next_cell[1]] == 'A':
+                    self.hidden_apples.append([next_cell[0], next_cell[1]])
                 self.map[next_cell[0], next_cell[1]] = 'F'
                 firing_points.append((next_cell[0], next_cell[1], 'F'))
                 start_pos += firing_direction

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -394,6 +394,8 @@ class TestHarvestEnv(unittest.TestCase):
         self.assertTrue(reward_1 == -1)
 
     def test_agent_conflict(self):
+        '''Test that agent conflicts are correctly resolved'''
+
         # test that if there are two agents and two spawning points, they hit both of them
         self.env = HarvestEnv(ascii_map=MINI_HARVEST_MAP, num_agents=2)
         self.env.reset()
@@ -473,6 +475,35 @@ class TestHarvestEnv(unittest.TestCase):
         agent_1_percent = num_agent_1 / (num_agent_1 + other_agents)
         within_bounds = .25 < agent_1_percent and agent_1_percent < .35
         self.assertTrue(within_bounds)
+
+    def test_beam_conflict(self):
+        """Test that after the beam is fired, obscured apples and agents are returned"""
+        self.env = HarvestEnv(ascii_map=MINI_HARVEST_MAP, num_agents=2)
+        self.env.reset()
+
+        # test that agents can't walk into other agents
+        self.env.agents['agent-0'].update_map_agent_pos([4, 2])
+        self.env.agents['agent-1'].update_map_agent_pos([4, 4])
+        self.env.agents['agent-0'].update_map_agent_rot('UP')
+        self.env.agents['agent-1'].update_map_agent_rot('UP')
+        # test that if an agents firing beam hits another agent it gets covered
+        self.env.update_map({'agent-1': 'FIRE'})
+        self.env.execute_reservations()
+        expected_map = np.array([['@', '@', '@', '@', '@', '@'],
+                                 ['@', ' ', ' ', ' ', ' ', '@'],
+                                 ['@', ' ', ' ', 'A', 'A', '@'],
+                                 ['@', ' ', ' ', 'A', 'A', '@'],
+                                 ['@', 'F', 'F', 'F', 'P', '@'],
+                                 ['@', '@', '@', '@', '@', '@']])
+        np.testing.assert_array_equal(expected_map, self.env.map)
+        self.env.update_map({})
+        expected_map = np.array([['@', '@', '@', '@', '@', '@'],
+                                 ['@', ' ', ' ', ' ', ' ', '@'],
+                                 ['@', ' ', ' ', 'A', 'A', '@'],
+                                 ['@', ' ', ' ', 'A', 'A', '@'],
+                                 ['@', ' ', 'P', 'A', 'P', '@'],
+                                 ['@', '@', '@', '@', '@', '@']])
+        np.testing.assert_array_equal(expected_map, self.env.map)
 
     def clear_agents(self):
         # FIXME(ev) this doesn't clear agent positions off the board


### PR DESCRIPTION
- Apples that were temporarily obscured by a fining beam are returned to the map after being obscured.