### PR TITLE
bug fix for apple spawning, moved execute_reservations into map_env

### DIFF
--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -75,14 +75,10 @@ class HarvestEnv(MapEnv):
             agent = HarvestAgent(agent_id, self.spawn_point(), self.spawn_rotation(), self, 3)
             self.agents[agent_id] = agent
 
-    # TODO(ev) this can probably be moved into the superclass
-    def reset_map(self):
-        self.map = np.full((len(self.base_map), len(self.base_map[0])), ' ')
+    def custom_reset(self):
         self.firing_points = []
 
-        self.build_walls()
         self.update_map_apples(self.apple_points)
-        self.setup_agents()
 
     def custom_action(self, agent):
         agent.fire_beam()

--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -13,22 +13,6 @@ COLOURS = {' ': [0, 0, 0],  # Black background
            'P': [0, 255, 255],  # Player #FIXME(ev) agents need to have different colors
            'F': [255, 255, 0]}  # Yellow firing beam
 
-# the axes look like
-# graphic is here to help me get my head in order
-# WARNING: increasing array position in the direction of down
-# so for example if you move_left when facing left
-# your y position decreases.
-#         ^
-#         |
-#         U
-#         P
-# <--LEFT*RIGHT---->
-#         D
-#         O
-#         W
-#         N
-#         |
-
 # Add custom actions to the agent
 ACTIONS['FIRE'] = 5
 

--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -77,8 +77,14 @@ class HarvestEnv(MapEnv):
 
     def custom_reset(self):
         self.firing_points = []
-
+        self.build_walls()
         self.update_map_apples(self.apple_points)
+
+    # TODO(ev) this is almost certainly used by every environment
+    def build_walls(self):
+        for i in range(len(self.wall_points)):
+            row, col = self.wall_points[i]
+            self.map[row, col] = '@'
 
     def custom_action(self, agent):
         agent.fire_beam()
@@ -147,11 +153,6 @@ class HarvestEnv(MapEnv):
         counts_dict = dict(zip(unique, counts))
         num_apples = counts_dict.get('A', 0)
         return num_apples
-
-    def build_walls(self):
-        for i in range(len(self.wall_points)):
-            row, col = self.wall_points[i]
-            self.map[row, col] = '@'
 
     def update_map_fire(self, firing_pos, firing_orientation):
         num_fire_cells = 5

--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -84,33 +84,10 @@ class HarvestEnv(MapEnv):
         self.update_map_apples(self.apple_points)
         self.setup_agents()
 
-    def update_map(self, agent_actions):
-        """Converts agent action tuples into a new map and new agent positions
-
-        Parameters
-        ----------
-        agent_actions: dict
-            dict with agent_id as key and action as value
-        """
-
-        # TODO(ev) split into three methods: clean(), update_map, custom_update_map
-        self.clean_firing_points()
-
-        for agent_id, action in agent_actions.items():
-            agent = self.agents[agent_id]
-            selected_action = ACTIONS[action]
-            if 'MOVE' in action or 'STAY' in action:
-                # rotate the selected action appropriately
-                rot_action = self.rotate_action(selected_action, agent.get_orientation())
-                new_pos = agent.get_pos() + rot_action
-                self.reserved_slots.append((*new_pos, 'P', agent_id))
-            elif 'TURN' in action:
-                new_rot = self.update_rotation(action, agent.get_orientation())
-                agent.update_map_agent_rot(new_rot)
-            else:
-                agent.fire_beam()
-                self.reserved_slots += self.update_map_fire(agent.get_pos().tolist(),
-                                                            agent.get_orientation())
+    def custom_action(self, agent):
+        agent.fire_beam()
+        self.reserved_slots += self.update_map_fire(agent.get_pos().tolist(),
+                                                    agent.get_orientation())
 
     def execute_custom_reservations(self):
         apple_pos = []
@@ -136,7 +113,7 @@ class HarvestEnv(MapEnv):
         if len(new_apples) > 0:
             self.reserved_slots += new_apples
 
-    def clean_firing_points(self):
+    def clean_map(self):
         agent_pos = []
         for agent in self.agents.values():
             agent_pos.append(agent.get_pos().tolist())

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -188,8 +188,10 @@ class MapEnv(Env):
     def reset_map(self):
         self.map = np.full((len(self.base_map), len(self.base_map[0])), ' ')
         self.setup_agents()
-        self.build_walls()
         self.custom_reset()
+
+    def custom_reset(self):
+        pass
 
     def custom_action(self, agent):
         pass

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -21,6 +21,22 @@ ORIENTATIONS = {'LEFT': [-1, 0],
                 'UP': [0, -1],
                 'DOWN': [0, 1]}
 
+# the axes look like
+# graphic is here to help me get my head in order
+# WARNING: increasing array position in the direction of down
+# so for example if you move_left when facing left
+# your y position decreases.
+#         ^
+#         |
+#         U
+#         P
+# <--LEFT*RIGHT---->
+#         D
+#         O
+#         W
+#         N
+#         |
+
 
 class MapEnv(Env):
 

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -152,7 +152,65 @@ class MapEnv(Env):
         pass
 
     def execute_reservations(self):
-        # executes the queued actions and map updates
+        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
+        agent_by_pos = {tuple(agent.get_pos()): agent.agent_id for agent in self.agents.values()}
+
+        # agent moves keyed by ids
+        agent_moves = {}
+
+        # lists of moves and their corresponding agents
+        move_slots = []
+        agent_to_slot = []
+
+        for slot in self.reserved_slots:
+            row, col = slot[0], slot[1]
+            if slot[2] == 'P':
+                agent_id = slot[3]
+                agent_moves[agent_id] = [row, col]
+                move_slots.append([row, col])
+                agent_to_slot.append(agent_id)
+
+        # First, resolve conflicts between two agents that want the same spot
+        if len(agent_to_slot) > 0:
+
+            # a random agent will win the slot
+            shuffle_list = list(zip(agent_to_slot, move_slots))
+            np.random.shuffle(shuffle_list)
+            agent_to_slot, move_slots = zip(*shuffle_list)
+            unique_move, indices, return_count = np.unique(move_slots, return_index=True,
+                                                           return_counts=True, axis=0)
+            search_list = np.array(move_slots)
+            # if there are any conflicts over a space
+            if np.any(return_count > 1):
+                for move, index, count in zip(unique_move, indices, return_count):
+                    if count > 1:
+                        self.agents[agent_to_slot[index]].update_map_agent_pos(move)
+                        # remove all the other moves that would have conflicted
+                        remove_indices = np.where((search_list == move).all(axis=1))[0]
+                        all_agents_id = [agent_to_slot[i] for i in remove_indices]
+                        # all other agents now stay in place
+                        for agent_id in all_agents_id:
+                            agent_moves[agent_id] = self.agents[agent_id].get_pos().tolist()
+
+            for agent_id, move in agent_moves.items():
+                if move in curr_agent_pos:
+                    # find the agent that is currently at that spot, check where they will be next
+                    # if they're going to move away, go ahead and move into their spot
+                    conflicting_agent_id = agent_by_pos[tuple(move)]
+                    # a STAY command has been issued or the other agent hasn't been issued a command,
+                    # don't do anything
+                    if agent_id == conflicting_agent_id or \
+                            conflicting_agent_id not in agent_moves.keys():
+                        continue
+                    elif agent_moves[conflicting_agent_id] != move:
+                        self.agents[agent_id].update_map_agent_pos(move)
+                else:
+                    self.agents[agent_id].update_map_agent_pos(move)
+
+        self.execute_custom_reservations()
+        self.reserved_slots = []
+
+    def execute_custom_reservations(self):
         raise NotImplementedError
 
     def setup_agents(self):

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -73,9 +73,6 @@ class MapEnv(Env):
                 arr[row, col] = ascii_list[row][col]
         return arr
 
-    def reset_map(self):
-        raise NotImplementedError
-
     def step(self, actions):
         """Takes in a dict of actions and converts them to a map update
 
@@ -186,6 +183,13 @@ class MapEnv(Env):
                 agent.update_map_agent_rot(new_rot)
             else:
                 self.custom_action(agent)
+
+    # TODO(ev) this can probably be moved into the superclass
+    def reset_map(self):
+        self.map = np.full((len(self.base_map), len(self.base_map[0])), ' ')
+        self.setup_agents()
+        self.build_walls()
+        self.custom_reset()
 
     def custom_action(self, agent):
         pass

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -160,8 +160,41 @@ class MapEnv(Env):
         """
         raise NotImplementedError
 
+    def update_map(self, agent_actions):
+        """Converts agent action tuples into a new map and new agent positions
+
+        Parameters
+        ----------
+        agent_actions: dict
+            dict with agent_id as key and action as value
+        """
+
+        # TODO(ev) split into three methods: clean(), update_map, custom_update_map
+        self.clean_map()
+
+        for agent_id, action in agent_actions.items():
+            agent = self.agents[agent_id]
+            selected_action = ACTIONS[action]
+            # TODO(ev) these two parts of the actions
+            if 'MOVE' in action or 'STAY' in action:
+                # rotate the selected action appropriately
+                rot_action = self.rotate_action(selected_action, agent.get_orientation())
+                new_pos = agent.get_pos() + rot_action
+                self.reserved_slots.append((*new_pos, 'P', agent_id))
+            elif 'TURN' in action:
+                new_rot = self.update_rotation(action, agent.get_orientation())
+                agent.update_map_agent_rot(new_rot)
+            else:
+                self.custom_action(agent)
+
+    def custom_action(self, agent):
+        pass
+
     def custom_map_update(self):
         """Custom map updates that don't have to do with agent actions"""
+        pass
+
+    def clean_map(self):
         pass
 
     def execute_reservations(self):

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -123,7 +123,6 @@ class MapEnv(Env):
         self.reserved_slots = []
         self.reset_map()
         self.custom_map_update()
-        # TODO(ev) the agent pos and orientation setting code is duplicated
 
         observations = {}
         for agent in self.agents.values():
@@ -273,7 +272,6 @@ class MapEnv(Env):
         -------
         view: (np.ndarray) - a slice of the map for the agent to see
         """
-        # FIXME(ev) this might be transposed
         x, y = pos
         left_edge = x - col_size
         right_edge = x + col_size
@@ -291,7 +289,6 @@ class MapEnv(Env):
         row_dim = matrix.shape[0]
         col_dim = matrix.shape[1]
         left_pad, right_pad, top_pad, bot_pad = 0, 0, 0, 0
-        # TODO(ev) this can be more elegantly written in terms of mins and maxes
         if left_edge < 0:
             left_pad = abs(left_edge)
         if right_edge > col_dim - 1:

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -222,6 +222,44 @@ class TestHarvestEnv(unittest.TestCase):
         num_apples = self.env.count_apples(self.env.map)
         self.assertEqual(num_apples, 5)
 
+        # Now, if a point is temporarily obscured by a beam but an apple should spawn there
+        # check that the apple still spawns there
+        self.env = HarvestEnv(ascii_map=MINI_HARVEST_MAP, num_agents=2)
+        self.env.reset()
+
+        # test that agents can't walk into other agents
+        self.env.agents['agent-0'].update_map_agent_pos([3, 1])
+        self.env.agents['agent-1'].update_map_agent_pos([3, 3])
+        self.env.agents['agent-0'].update_map_agent_rot('UP')
+        self.env.agents['agent-1'].update_map_agent_rot('UP')
+        # test that if an agents firing beam hits another agent it gets covered
+        self.env.update_map({'agent-1': 'FIRE'})
+        self.env.execute_reservations()
+        self.env.update_map_apples([[3, 2]])
+        self.env.update_map({})
+        expected_map = np.array([['@', '@', '@', '@', '@', '@'],
+                                 ['@', ' ', ' ', ' ', ' ', '@'],
+                                 ['@', ' ', ' ', 'A', 'A', '@'],
+                                 ['@', 'P', 'A', 'P', 'A', '@'],
+                                 ['@', ' ', ' ', 'A', ' ', '@'],
+                                 ['@', '@', '@', '@', '@', '@']])
+        np.testing.assert_array_equal(expected_map, self.env.map)
+
+        # If an agent is temporarily obscured by a beam, and an apple attempts to spawn there
+        # no apple should spawn
+        self.env.update_map({'agent-1': 'FIRE'})
+        self.env.execute_reservations()
+        self.env.update_map_apples([[3, 1]])
+        self.env.update_map({})
+        expected_map = np.array([['@', '@', '@', '@', '@', '@'],
+                                 ['@', ' ', ' ', ' ', ' ', '@'],
+                                 ['@', ' ', ' ', 'A', 'A', '@'],
+                                 ['@', 'P', 'A', 'P', 'A', '@'],
+                                 ['@', ' ', ' ', 'A', ' ', '@'],
+                                 ['@', '@', '@', '@', '@', '@']])
+        np.testing.assert_array_equal(expected_map, self.env.map)
+
+
     def test_agent_actions(self):
         # FIXME(ev) the axes are 10000000% rotated oddly
         # set up the map

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -370,7 +370,7 @@ class TestHarvestEnv(unittest.TestCase):
         )
         np.testing.assert_array_equal(expected_view, agent_view)
 
-        self.env.clean_firing_points()
+        self.env.clean_map()
 
         self.rotate_agent(agent_id, 'DOWN')
         self.move_agent(agent_id, [3, 2])

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -259,9 +259,7 @@ class TestHarvestEnv(unittest.TestCase):
                                  ['@', '@', '@', '@', '@', '@']])
         np.testing.assert_array_equal(expected_map, self.env.map)
 
-
     def test_agent_actions(self):
-        # FIXME(ev) the axes are 10000000% rotated oddly
         # set up the map
         agent_id = 'agent-0'
         self.construct_map(TEST_MAP_1.copy(), agent_id, [2, 2], 'LEFT')


### PR DESCRIPTION
- Apples that were temporarily obscured by a fining beam are returned to the map after being obscured.
- Apples cannot spawn where a temporarily obscured agents are
- Fixes #45 
- Moved most of execute_reservation into the map_env
- Fixes #21 