### PR TITLE
Cleanup fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,19 @@ Every environment that subclasses MapEnv needs to implement the following method
       (row, col, 'A') to env.reserved_slots to indicate an apple should be placed at that point"""
       pass
 
-  def clean_map(self):
-      """Clean map of elements that should be removed at the start of every step"""
-      pass
+  def append_hiddens(self, new_pos, old_char, new_char):
+      """Add cells that will be hidden and should be put back later
+
+      Parameters
+      ----------
+      new_pos: list
+          the position the new char is going to be placed at
+      old_char: str
+          the character that will be hidden
+      new_char: str
+          the character that will replace it
+      """
+      raise NotImplementedError
 
    def execute_custom_reservations(self):
     """Execute reserved slots that do not have to do with moving agents. For example, placing apples 

--- a/rollout.py
+++ b/rollout.py
@@ -1,8 +1,8 @@
 """Defines a multi-agent controller to rollout environment episodes w/
    agent policies."""
 
-from social_dilemmas.envs.harvest import HarvestEnv
-# from social_dilemmas.envs.cleanup import CleanupEnv
+# from social_dilemmas.envs.harvest import HarvestEnv
+from social_dilemmas.envs.cleanup import CleanupEnv
 
 import utility_funcs
 import numpy as np
@@ -14,13 +14,13 @@ import shutil
 class Controller(object):
 
     def __init__(self):
-        self.env = HarvestEnv(num_agents=5, render=True)
+        self.env = CleanupEnv(num_agents=5, render=True)
         self.env.reset()
 
         # TODO: initialize agents here
 
-    def rollout_and_render(self, horizon=100000, render_frames=False,
-                           render_full_vid=False, path=None):
+    def rollout_and_render(self, horizon=1000, render_frames=False,
+                           render_full_vid=True, path=None):
         rewards = []
         observations = []
 

--- a/rollout.py
+++ b/rollout.py
@@ -1,8 +1,8 @@
 """Defines a multi-agent controller to rollout environment episodes w/
    agent policies."""
 
-# from social_dilemmas.envs.harvest import HarvestEnv
-from social_dilemmas.envs.cleanup import CleanupEnv
+from social_dilemmas.envs.harvest import HarvestEnv
+# from social_dilemmas.envs.cleanup import CleanupEnv
 
 import utility_funcs
 import numpy as np
@@ -14,7 +14,7 @@ import shutil
 class Controller(object):
 
     def __init__(self):
-        self.env = CleanupEnv(num_agents=5, render=True)
+        self.env = HarvestEnv(num_agents=5, render=True)
         self.env.reset()
 
         # TODO: initialize agents here

--- a/rollout.py
+++ b/rollout.py
@@ -19,8 +19,8 @@ class Controller(object):
 
         # TODO: initialize agents here
 
-    def rollout_and_render(self, horizon=1000, render_frames=False,
-                           render_full_vid=True, path=None):
+    def rollout_and_render(self, horizon=100000, render_frames=False,
+                           render_full_vid=False, path=None):
         rewards = []
         observations = []
 

--- a/social_dilemmas/envs/agent.py
+++ b/social_dilemmas/envs/agent.py
@@ -26,7 +26,7 @@ class Agent(object):
             how many columns left and right the agent can look
         """
         self.agent_id = agent_id
-        self.pos = start_pos
+        self.pos = np.array(start_pos)
         self.orientation = start_orientation
         # TODO(ev) change grid to env, this name is not very informative
         self.grid = grid
@@ -94,23 +94,29 @@ class Agent(object):
         return self.grid.map
 
     def update_map_agent_pos(self, new_pos):
+        """Updates the agents internal positions
+
+        Returns
+        -------
+        old_pos: (np.ndarray)
+            2-d array describing where the agent used to be
+        new_pos: (np.ndarray)
+            2-d array describing the agent positions
+        """
         new_row, new_col = new_pos
-        old_row, old_col = self.get_pos()
+        old_pos = self.get_pos()
         self.reward_from_pos(new_pos)
-        # you can't walk through walls or agents
+        # you can't walk through walls
         if self.grid.map[new_row, new_col] == '@':
             new_pos = self.get_pos()
-        else:
-            self.grid.map[old_row, old_col] = ' '
-            self.grid.map[new_row, new_col] = 'P'
 
         self.set_pos(new_pos)
+        # TODO(ev) list array consistency
+        return self.get_pos(), np.array(old_pos)
 
     def update_map_agent_rot(self, new_rot):
         # FIXME(ev) once we have a color scheme worked out we need to convert rotation
         # into a color
-        row, col = self.get_pos()
-        self.grid.map[row, col] = 'P'
         self.set_orientation(new_rot)
 
 
@@ -175,7 +181,6 @@ class CleanupAgent(Agent):
         self.view_len = view_len
         super().__init__(agent_id, start_pos, start_orientation, grid, view_len, view_len)
         # remember what you've stepped on
-        self.memory = self.grid.map[start_pos[0], start_pos[1]]
         self.update_map_agent_pos(start_pos)
         self.update_map_agent_rot(start_orientation)
 

--- a/social_dilemmas/envs/agent.py
+++ b/social_dilemmas/envs/agent.py
@@ -212,28 +212,5 @@ class CleanupAgent(Agent):
     def fire_beam(self):
         self.reward_this_turn -= 1
 
-    def update_map_agent_pos(self, new_pos):
-        new_row, new_col = new_pos
-        old_row, old_col = self.get_pos()
-        self.reward_from_pos(new_pos)
-        # don't change memory or move if no call to move was made
-        if new_row != old_row or new_col != old_col:
-            # apples and firing beams should not be placed back
-            if self.memory == 'A' or self.memory == 'F':
-                self.grid.map[old_row, old_col] = ' '
-            else:
-                self.grid.map[old_row, old_col] = self.memory
-
-            # you can't walk through walls or agents
-            # TODO(ev) if you attempt to walk through a wall, you can disappear
-            if self.grid.map[new_row, new_col] == '@':
-                new_pos = self.get_pos()
-                self.memory = self.grid.map[new_pos[0], new_pos[1]]
-            else:
-                self.memory = self.grid.map[new_pos[0], new_pos[1]]
-                self.grid.map[new_row, new_col] = 'P'
-
-            self.set_pos(new_pos)
-
     def get_done(self):
         return False

--- a/social_dilemmas/envs/cleanup.py
+++ b/social_dilemmas/envs/cleanup.py
@@ -121,7 +121,7 @@ class CleanupEnv(MapEnv):
             self.hidden_cells.append(new_pos + [' '])
         # a waste cell is gone if a firing cell hits it
         if old_char == 'H' and new_char == 'F':
-            self.hidden_cells.append(new_pos + 'R')
+            self.hidden_cells.append(new_pos + ['R'])
         else:
             self.hidden_cells.append(new_pos + [old_char])
 
@@ -136,13 +136,13 @@ class CleanupEnv(MapEnv):
         spawn_points = []
         for i in range(len(self.apple_points)):
             row, col = self.apple_points[i]
-            if self.map[row, col] != 'P':
+            if self.map[row, col] != 'P' and self.map[row, col] != 'A':
                 rand_num = np.random.rand(1)[0]
                 if rand_num < self.current_apple_spawn_prob:
                     spawn_points.append((row, col, 'A'))
         for i in range(len(self.waste_points)):
             row, col = self.waste_points[i]
-            if self.map[row, col] != 'P':
+            if self.map[row, col] != 'P' and self.map[row, col] != 'H':
                 rand_num = np.random.rand(1)[0]
                 if rand_num < self.current_waste_spawn_prob:
                     spawn_points.append((row, col, 'H'))

--- a/social_dilemmas/envs/cleanup.py
+++ b/social_dilemmas/envs/cleanup.py
@@ -40,25 +40,17 @@ class CleanupEnv(MapEnv):
 
         # make a list of the potential apple and waste spawn points
         self.apple_points = []
+        self.firing_points = []
         self.waste_start_points = []
         self.waste_points = []
         self.river_points = []
         self.stream_points = []
-        self.wall_points = []
-        self.firing_points = []
-        self.hidden_apples = []
-        self.hidden_river = []
-        self.hidden_stream = []
-        self.hidden_agents = []
-        self.hidden_waste = []
         for row in range(self.base_map.shape[0]):
             for col in range(self.base_map.shape[1]):
                 if self.base_map[row, col] == 'P':
                     self.spawn_points.append([row, col])
                 elif self.base_map[row, col] == 'B':
                     self.apple_points.append([row, col])
-                elif self.base_map[row, col] == '@':
-                    self.wall_points.append([row, col])
                 elif self.base_map[row, col] == 'S':
                     self.stream_points.append([row, col])
                 if self.base_map[row, col] == 'H':
@@ -67,9 +59,6 @@ class CleanupEnv(MapEnv):
                     self.waste_points.append([row, col])
                 if self.base_map[row, col] == 'R':
                     self.river_points.append([row, col])
-
-        # TODO(ev) this call should be in the superclass
-        self.setup_agents()
 
     @property
     def action_space(self):
@@ -85,12 +74,6 @@ class CleanupEnv(MapEnv):
     def custom_reset(self):
         """Initialize the walls and the waste"""
         self.firing_points = []
-        self.hidden_apples = []
-        self.hidden_river = []
-        self.hidden_stream = []
-        self.hidden_agents = []
-        self.hidden_waste = []
-        self.build_walls()
         self.update_map_waste(self.waste_start_points)
         self.update_map_river(self.river_points)
         self.update_map_stream(self.stream_points)
@@ -108,30 +91,6 @@ class CleanupEnv(MapEnv):
         new_apples_and_waste = self.spawn_apples_and_waste()
         if len(new_apples_and_waste) > 0:
             self.reserved_slots += new_apples_and_waste
-
-    def clean_map(self):
-        """Clean map of elements that should be removed. Executed every step"""
-        agent_pos = []
-        for agent in self.agents.values():
-            agent_pos.append(agent.get_pos().tolist())
-        for i in range(len(self.firing_points)):
-            # TODO(ev) replace this with a map memory of obscured cells
-            row, col = self.firing_points[i]
-            if self.firing_points[i] in self.hidden_apples:
-                self.map[row, col] = 'A'
-            elif [row, col] in agent_pos:
-                # put the agent back if they were temporarily obscured by the firing beam
-                self.map[row, col] = 'P'
-            elif self.firing_points[i] in self.hidden_river:
-                self.map[row, col] = 'R'
-            elif self.firing_points[i] in self.hidden_stream:
-                self.map[row, col] = 'S'
-            else:
-                self.map[row, col] = ' '
-        self.hidden_apples = []
-        self.firing_points = []
-        self.hidden_agents = []
-        self.hidden_river = []
 
     def execute_custom_reservations(self):
         """Execute firing and then apple spawning"""
@@ -154,6 +113,17 @@ class CleanupEnv(MapEnv):
         # update the apples
         self.update_map_apples(apple_pos)
         self.update_map_waste(waste_pos)
+
+    def append_hiddens(self, new_pos, old_char, new_char=None):
+        """Add hidden cells to self.hidden_cells that should be put back when cleaning"""
+        # an apple is gone once an agent walks over it
+        if old_char == 'A' and new_char == 'P':
+            self.hidden_cells.append(new_pos + [' '])
+        # a waste cell is gone if a firing cell hits it
+        if old_char == 'H' and new_char == 'F':
+            self.hidden_cells.append(new_pos + 'R')
+        else:
+            self.hidden_cells.append(new_pos + [old_char])
 
     def setup_agents(self):
         """Constructs all the agents in self.agent"""
@@ -209,12 +179,14 @@ class CleanupEnv(MapEnv):
                 self.map[row, col] = 'H'
 
     def update_map_apples(self, new_apple_points):
+        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
         for i in range(len(new_apple_points)):
             row, col = new_apple_points[i]
             if self.map[row, col] != 'P' and self.map[row, col] != 'F':
                 self.map[row, col] = 'A'
-            elif self.map[row, col] == 'F' and [row, col] not in self.hidden_agents:
-                self.hidden_apples.append([row, col])
+            # you can't spawn apples if an agent is there but hidden by a beam,
+            elif self.map[row, col] == 'F' and [row, col] not in curr_agent_pos:
+                self.append_hiddens([row, col], 'A')
 
     def update_map_river(self, new_river_points):
         for i in range(len(new_river_points)):
@@ -226,6 +198,7 @@ class CleanupEnv(MapEnv):
             row, col = new_stream_points[i]
             self.map[row, col] = 'S'
 
+    # TODO(ev) this is in two classes already
     def update_map_fire(self, firing_pos, firing_orientation):
         num_fire_cells = ACTIONS['FIRE']
         start_pos = np.asarray(firing_pos)
@@ -239,25 +212,10 @@ class CleanupEnv(MapEnv):
             for i in range(num_fire_cells):
                 next_cell = pos + firing_direction
                 if self.test_if_in_bounds(next_cell) and self.map[next_cell[0], next_cell[1]] != '@':
-                    # there should be a river cell here, do not replace
-                    if self.base_map[next_cell[0], next_cell[1]] == 'H' or \
-                            self.base_map[next_cell[0], next_cell[1]] == 'R':
-                        self.hidden_river.append([next_cell[0], next_cell[1]])
-                    elif self.map[next_cell[0], next_cell[1]] == 'A':
-                        self.hidden_apples.append([next_cell[0], next_cell[1]])
-                    elif self.map[next_cell[0], next_cell[1]] == 'P':
-                        self.hidden_agents.append([next_cell[0], next_cell[1]])
-                    elif self.map[next_cell[0], next_cell[1]] == 'S':
-                        self.hidden_stream.append([next_cell[0], next_cell[1]])
-                    self.map[next_cell[0], next_cell[1]] = 'F'
+                    char = self.map[next_cell[0], next_cell[1]]
+                    self.append_hiddens([next_cell[0], next_cell[1]], char, 'F')
                     firing_points.append((next_cell[0], next_cell[1], 'F'))
                     pos += firing_direction
                 else:
                     break
         return firing_points
-
-    # TODO(ev) this is duplicated in Harvest so it should be moved into MapEnv
-    def build_walls(self):
-        for i in range(len(self.wall_points)):
-            row, col = self.wall_points[i]
-            self.map[row, col] = '@'

--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -107,7 +107,7 @@ class HarvestEnv(MapEnv):
         new_apple_points = []
         for i in range(len(self.apple_points)):
             row, col = self.apple_points[i]
-            if self.map[row, col] != 'P':
+            if self.map[row, col] != 'P' and self.map[row, col] != 'A':
                 window = self.return_view(self.apple_points[i], APPLE_RADIUS, APPLE_RADIUS)
                 num_apples = self.count_apples(window)
                 spawn_prob = SPAWN_PROB[min(num_apples, 3)]

--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -27,22 +27,12 @@ class HarvestEnv(MapEnv):
 
     def __init__(self, ascii_map=HARVEST_MAP, num_agents=1, render=False):
         super().__init__(ascii_map, COLOURS, num_agents, render)
-        # set up the list of spawn points
-        self.apple_points = []
-        self.wall_points = []
         self.firing_points = []
-        self.hidden_apples = []
-        self.hidden_agents = []
+        self.apple_points = []
         for row in range(self.base_map.shape[0]):
             for col in range(self.base_map.shape[1]):
-                if self.base_map[row, col] == 'P':
-                    self.spawn_points.append([row, col])
-                elif self.base_map[row, col] == 'A':
+                if self.base_map[row, col] == 'A':
                     self.apple_points.append([row, col])
-                elif self.base_map[row, col] == '@':
-                    self.wall_points.append([row, col])
-        # TODO(ev) this call should be in the superclass
-        self.setup_agents()
 
     # FIXME(ev) action_space should really be defined in the agents
     @property
@@ -65,9 +55,6 @@ class HarvestEnv(MapEnv):
     def custom_reset(self):
         """Initialize the walls and the apples"""
         self.firing_points = []
-        self.hidden_apples = []
-        self.hidden_agents = []
-        self.build_walls()
         self.update_map_apples(self.apple_points)
 
     def custom_action(self, agent):
@@ -82,24 +69,6 @@ class HarvestEnv(MapEnv):
         if len(new_apples) > 0:
             self.reserved_slots += new_apples
 
-    def clean_map(self):
-        """Put back agents and apples that were hidden by the fining beam"""
-        agent_pos = []
-        for agent in self.agents.values():
-            agent_pos.append(agent.get_pos().tolist())
-        for i in range(len(self.firing_points)):
-            row, col = self.firing_points[i]
-            if self.firing_points[i] in self.hidden_apples:
-                self.map[row, col] = 'A'
-            elif [row, col] in agent_pos:
-                # put the agent back if they were temporarily obscured by the firing beam
-                self.map[row, col] = 'P'
-            else:
-                self.map[row, col] = ' '
-        self.hidden_apples = []
-        self.firing_points = []
-        self.hidden_agents = []
-
     def execute_custom_reservations(self):
         """Execute firing and then apple spawning"""
         apple_pos = []
@@ -113,16 +82,18 @@ class HarvestEnv(MapEnv):
         for pos in firing_pos:
             row, col = pos
             self.map[row, col] = 'F'
-            self.firing_points.append([row, col])
 
         # update the apples
         self.update_map_apples(apple_pos)
 
-    # TODO(ev) this is almost certainly used by every environment
-    def build_walls(self):
-        for i in range(len(self.wall_points)):
-            row, col = self.wall_points[i]
-            self.map[row, col] = '@'
+    def append_hiddens(self, new_pos, old_char, new_char=None):
+        """Add hidden cells to self.hidden_cells that should be put back when cleaning"""
+        # an apple is gone once an agent walks over it
+
+        if old_char == 'A' and new_char == 'P':
+            self.hidden_cells.append(new_pos + [' '])
+        else:
+            self.hidden_cells.append(new_pos + [old_char])
 
     def spawn_apples(self):
         """Construct the apples spawned in this step.
@@ -165,11 +136,8 @@ class HarvestEnv(MapEnv):
             for i in range(num_fire_cells):
                 next_cell = pos + firing_direction
                 if self.test_if_in_bounds(next_cell) and self.map[next_cell[0], next_cell[1]] != '@':
-                    if self.map[next_cell[0], next_cell[1]] == 'A':
-                        self.hidden_apples.append([next_cell[0], next_cell[1]])
-                    elif self.map[next_cell[0], next_cell[1]] == 'P':
-                        self.hidden_agents.append([next_cell[0], next_cell[1]])
-                    self.map[next_cell[0], next_cell[1]] = 'F'
+                    char = self.map[next_cell[0], next_cell[1]]
+                    self.append_hiddens([next_cell[0], next_cell[1]], char, 'F')
                     firing_points.append((next_cell[0], next_cell[1], 'F'))
                     pos += firing_direction
                 else:
@@ -177,9 +145,11 @@ class HarvestEnv(MapEnv):
         return firing_points
 
     def update_map_apples(self, new_apple_points):
+        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
         for i in range(len(new_apple_points)):
             row, col = new_apple_points[i]
             if self.map[row, col] != 'P' and self.map[row, col] != 'F':
                 self.map[row, col] = 'A'
-            elif self.map[row, col] == 'F' and [row, col] not in self.hidden_agents:
-                self.hidden_apples.append([row, col])
+            # you can't spawn apples if an agent is there but hidden by a bea,
+            elif self.map[row, col] == 'F' and [row, col] not in curr_agent_pos:
+                self.append_hiddens([row, col], 'A')

--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -123,6 +123,17 @@ class HarvestEnv(MapEnv):
         num_apples = counts_dict.get('A', 0)
         return num_apples
 
+    def update_map_apples(self, new_apple_points):
+        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
+        for i in range(len(new_apple_points)):
+            row, col = new_apple_points[i]
+            if self.map[row, col] != 'P' and self.map[row, col] != 'F':
+                self.map[row, col] = 'A'
+            # you can't spawn apples if an agent is there but hidden by a beam,
+            elif self.map[row, col] == 'F' and [row, col] not in curr_agent_pos:
+                self.append_hiddens([row, col], 'A')
+
+    # TODO(ev) this is in two classes already
     def update_map_fire(self, firing_pos, firing_orientation):
         num_fire_cells = ACTIONS['FIRE']
         start_pos = np.asarray(firing_pos)
@@ -143,13 +154,3 @@ class HarvestEnv(MapEnv):
                 else:
                     break
         return firing_points
-
-    def update_map_apples(self, new_apple_points):
-        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
-        for i in range(len(new_apple_points)):
-            row, col = new_apple_points[i]
-            if self.map[row, col] != 'P' and self.map[row, col] != 'F':
-                self.map[row, col] = 'A'
-            # you can't spawn apples if an agent is there but hidden by a bea,
-            elif self.map[row, col] == 'F' and [row, col] not in curr_agent_pos:
-                self.append_hiddens([row, col], 'A')

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -342,12 +342,11 @@ class MapEnv(MultiAgentEnv):
                         # all other agents now stay in place
                         for agent_id in all_agents_id:
                             agent_moves[agent_id] = self.agents[agent_id].get_pos().tolist()
+                        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
+                        agent_by_pos = {tuple(agent.get_pos()): agent.agent_id for agent in self.agents.values()}
 
             while len(agent_moves.items()) > 0:
                 moves_copy = agent_moves.copy()
-                # if agent_moves == {'agent-0': [3, 4], 'agent-1': [2, 4]}:
-                #     import ipdb;
-                #     ipdb.set_trace()
                 del_keys = []
                 for agent_id, move in moves_copy.items():
                     if agent_id in del_keys:
@@ -396,50 +395,7 @@ class MapEnv(MultiAgentEnv):
                         del agent_moves[agent_id]
                         del_keys.append(agent_id)
                         curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
-                        # # The other agent is going to move out of the way, so move in
-                        # elif agent_moves[conflicting_agent_id] != move:
-                        #     new_pos, old_pos = self.agents[agent_id].update_map_agent_pos(move)
-                        #     # update the lists in case conflicts have resolved
-                        #     curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
-                        #     agent_by_pos = {tuple(agent.get_pos()): agent.agent_id for agent in self.agents.values()}
-                        #     new_pos = new_pos.tolist()
-                        #     old_pos = old_pos.tolist()
-                        #     char = self.map[new_pos[0], new_pos[1]]
-                        #     if old_pos in hidden_pos \
-                        #             and not np.array_equal(new_pos, old_pos):
-                        #         index = hidden_pos.index([old_pos[0], old_pos[1]])
-                        #         # if there is an agent that is not you in your old pos, don't delete
-                        #         # agent_by_pos is lagging so query it with your old id
-                        #         agent_in_old_pos = agent_by_pos.get((old_pos[0], old_pos[1]), False)
-                        #         if not agent_in_old_pos:
-                        #             self.map[old_pos[0], old_pos[1]] = self.hidden_cells[index][2]
-                        #             if char != 'P':
-                        #                 del self.hidden_cells[index]
-                        #                 self.append_hiddens(new_pos, char, 'P')
-                        #     self.map[new_pos[0], new_pos[1]] = 'P'
 
-        #         else:
-        #             new_pos, old_pos = self.agents[agent_id].update_map_agent_pos(move)
-        #             # update the lists in case conflicts have resolved
-        #             curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
-        #             agent_by_pos = {tuple(agent.get_pos()): agent.agent_id for agent in self.agents.values()}
-        #             new_pos = new_pos.tolist()
-        #             old_pos = old_pos.tolist()
-        #             char = self.map[new_pos[0], new_pos[1]]
-        #             if old_pos in hidden_pos \
-        #                     and not np.array_equal(new_pos, old_pos):
-        #                 index = hidden_pos.index([old_pos[0], old_pos[1]])
-        #                 agent_in_old_pos = agent_by_pos.get((old_pos[0], old_pos[1]), False)
-        #                 if not agent_in_old_pos:
-        #                     self.map[old_pos[0], old_pos[1]] = self.hidden_cells[index][2]
-        #                     if char != 'P':
-        #                         del self.hidden_cells[index]
-        #                         self.append_hiddens(new_pos, char, 'P')
-        #             self.map[new_pos[0], new_pos[1]] = 'P'
-        #
-        # if self.map[3, 3] == 'P' and self.map[3, 4] == 'P' and self.map[2, 4] == 'P':
-        #     import ipdb;
-        #     ipdb.set_trace()
         self.execute_custom_reservations()
         self.reserved_slots = []
 

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -66,6 +66,17 @@ class MapEnv(MultiAgentEnv):
         self.render = render
         self.color_map = color_map
         self.spawn_points = []  # where agents can appear
+        # cells hidden by agents or other actions, elements are [row, pos, str]
+        self.hidden_cells = []
+        self.wall_points = []
+        for row in range(self.base_map.shape[0]):
+            for col in range(self.base_map.shape[1]):
+                if self.base_map[row, col] == 'P':
+                    self.spawn_points.append([row, col])
+                elif self.base_map[row, col] == '@':
+                    self.wall_points.append([row, col])
+        self.setup_agents()
+
 
     # FIXME(ev) move this to a utils eventually
     def ascii_to_numpy(self, ascii_list):
@@ -103,11 +114,19 @@ class MapEnv(MultiAgentEnv):
             agent_action = self.agents[agent_id].action_map(action)
             agent_actions[agent_id] = agent_action
 
-        self.update_map(agent_actions)
+        # move
+        self.clean_map()
+        self.update_moves(agent_actions)
+        self.execute_reservations()
 
+        # execute custom moves like firing
+        self.clean_map()
+        self.update_custom_moves(agent_actions)
+        self.execute_reservations()
+
+        # execute spawning events
         self.custom_map_update()
         self.execute_reservations()
-        self.reserved_slots = []
 
         observations = {}
         rewards = {}
@@ -134,6 +153,9 @@ class MapEnv(MultiAgentEnv):
             to be zero.
         """
         self.reserved_slots = []
+        self.hidden_cells = []
+        self.agents = {}
+        self.setup_agents()
         self.reset_map()
         self.custom_map_update()
 
@@ -173,7 +195,7 @@ class MapEnv(MultiAgentEnv):
             plt.imshow(rgb_arr, interpolation='nearest')
             plt.show()
 
-    def update_map(self, agent_actions):
+    def update_moves(self, agent_actions):
         """Converts agent action tuples into a new map and new agent positions
 
         Parameters
@@ -181,9 +203,6 @@ class MapEnv(MultiAgentEnv):
         agent_actions: dict
             dict with agent_id as key and action as value
         """
-
-        # TODO(ev) split into three methods: clean(), update_map, custom_update_map
-        self.clean_map()
 
         for agent_id, action in agent_actions.items():
             agent = self.agents[agent_id]
@@ -197,13 +216,24 @@ class MapEnv(MultiAgentEnv):
             elif 'TURN' in action:
                 new_rot = self.update_rotation(action, agent.get_orientation())
                 agent.update_map_agent_rot(new_rot)
-            else:
+
+    def update_custom_moves(self, agent_actions):
+        for agent_id, action in agent_actions.items():
+            # check its not a move based action
+            if 'MOVE' not in action and 'STAY' not in action and 'TURN' not in action:
+                agent = self.agents[agent_id]
                 self.custom_action(agent)
 
     def reset_map(self):
         """Resets the map to be empty as well as a custom reset set by subclasses"""
         self.map = np.full((len(self.base_map), len(self.base_map[0])), ' ')
-        self.setup_agents()
+        for agent in self.agents.values():
+            pos = agent.get_pos()
+            row, col = pos
+            # TODO(ev) this rendering logic should not be done here)
+            self.map[row, col] = 'P'
+            self.append_hiddens(pos.tolist(), ' ', 'P')
+        self.build_walls()
         self.custom_reset()
 
     def custom_reset(self):
@@ -222,8 +252,18 @@ class MapEnv(MultiAgentEnv):
         pass
 
     def clean_map(self):
-        """Clean map of elements that should be removed at the start of every step"""
-        pass
+        """Place back all hidden cells that are not currently blocked by an agent"""
+        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
+        hidden_pos = [hidden[0:2] for hidden in self.hidden_cells]
+        hidden_char = [hidden[2] for hidden in self.hidden_cells]
+        for i, hidden in enumerate(hidden_pos):
+            # you can't put back hidden cells that an agent is on unless it is an agent that is
+            # hidden
+            if hidden not in curr_agent_pos or hidden_char[i] == 'P':
+                row, col = hidden
+                self.map[row, col] = hidden_char[i]
+                index = self.hidden_cells.index(hidden + [hidden_char[i]])
+                del self.hidden_cells[index]
 
     def execute_custom_reservations(self):
         """Execute reserved slots that do not have to do with moving agents. For example,
@@ -232,6 +272,20 @@ class MapEnv(MultiAgentEnv):
 
     def setup_agents(self):
         """Construct all the agents for the environment"""
+        raise NotImplementedError
+
+    def append_hiddens(self, new_pos, old_char, new_char):
+        """Add hidden cells to self.hidden_cells that should be put back
+
+        Parameters
+        ----------
+        new_pos: list
+            the position the new char is going to be placed at
+        old_char: str
+            the character that will be hidden
+        new_char: str
+            the character that will replace it
+        """
         raise NotImplementedError
 
     def execute_reservations(self):
@@ -277,19 +331,43 @@ class MapEnv(MultiAgentEnv):
                             agent_moves[agent_id] = self.agents[agent_id].get_pos().tolist()
 
             for agent_id, move in agent_moves.items():
+                hidden_pos = [hidden_cell[0: 2] for hidden_cell in self.hidden_cells]
                 if move in curr_agent_pos:
                     # find the agent that is currently at that spot, check where they will be next
                     # if they're going to move away, go ahead and move into their spot
                     conflicting_agent_id = agent_by_pos[tuple(move)]
+                    curr_pos = self.agents[agent_id].get_pos().tolist()
                     # a STAY command has been issued or the other agent hasn't been issued a command,
-                    # don't do anything
+                    # or the other agent is trying to move into your spot (i.e. agents can't
+                    # walk through each other) then so don't do anything
                     if agent_id == conflicting_agent_id or \
-                            conflicting_agent_id not in agent_moves.keys():
+                            agent_moves.get(conflicting_agent_id, curr_pos) == curr_pos:
                         continue
+                    # TODO(ev) this and the line below seem like code duplication
                     elif agent_moves[conflicting_agent_id] != move:
-                        self.agents[agent_id].update_map_agent_pos(move)
+                        new_pos, old_pos = self.agents[agent_id].update_map_agent_pos(move)
+                        new_pos = new_pos.tolist()
+                        old_pos = old_pos.tolist()
+                        char = self.map[new_pos[0], new_pos[1]]
+                        if old_pos in hidden_pos \
+                                and not np.array_equal(new_pos, old_pos):
+                            index = hidden_pos.index([old_pos[0], old_pos[1]])
+                            self.map[old_pos[0], old_pos[1]] = self.hidden_cells[index][2]
+                            del self.hidden_cells[index]
+                        self.map[new_pos[0], new_pos[1]] = 'P'
+
                 else:
-                    self.agents[agent_id].update_map_agent_pos(move)
+                    new_pos, old_pos = self.agents[agent_id].update_map_agent_pos(move)
+                    new_pos = new_pos.tolist()
+                    old_pos = old_pos.tolist()
+                    char = self.map[new_pos[0], new_pos[1]]
+                    if old_pos in hidden_pos \
+                            and not np.array_equal(new_pos, old_pos):
+                        index = hidden_pos.index([old_pos[0], old_pos[1]])
+                        self.map[old_pos[0], old_pos[1]] = self.hidden_cells[index][2]
+                        del self.hidden_cells[index]
+                        self.append_hiddens(new_pos, char, 'P')
+                    self.map[new_pos[0], new_pos[1]] = 'P'
 
         self.execute_custom_reservations()
         self.reserved_slots = []
@@ -316,11 +394,13 @@ class MapEnv(MultiAgentEnv):
         rand_int = 0
         # select a spawn point
         # replace this with an operation over a set
+        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
         while not not_occupied:
+            # TODO(ev), this is lazy, only spawn numbers that are valid
             num_ints = len(self.spawn_points)
             rand_int = np.random.randint(num_ints)
             spawn_point = self.spawn_points[rand_int]
-            if self.map[spawn_point[0], spawn_point[1]] != 'P':
+            if [spawn_point[0], spawn_point[1]] not in curr_agent_pos:
                 not_occupied = True
         return np.array(self.spawn_points[rand_int])
 
@@ -328,6 +408,11 @@ class MapEnv(MultiAgentEnv):
         """Return a randomly selected initial rotation for an agent"""
         rand_int = np.random.randint(len(ORIENTATIONS.keys()))
         return list(ORIENTATIONS.keys())[rand_int]
+
+    def build_walls(self):
+        for i in range(len(self.wall_points)):
+            row, col = self.wall_points[i]
+            self.map[row, col] = '@'
 
     ########################################
     # Utility methods, move these eventually

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -267,7 +267,6 @@ class MapEnv(MultiAgentEnv):
                 index = self.hidden_cells.index(hidden + [hidden_char[i]])
                 del self.hidden_cells[index]
 
-
     def execute_custom_reservations(self):
         """Execute reserved slots that do not have to do with moving agents. For example,
         placing apples or placing the fired beam. """
@@ -354,8 +353,10 @@ class MapEnv(MultiAgentEnv):
                         # all other agents now stay in place
                         for agent_id in all_agents_id:
                             agent_moves[agent_id] = self.agents[agent_id].get_pos().tolist()
-                        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
-                        agent_by_pos = {tuple(agent.get_pos()): agent.agent_id for agent in self.agents.values()}
+                        curr_agent_pos = [agent.get_pos().tolist() for
+                                          agent in self.agents.values()]
+                        agent_by_pos = {tuple(agent.get_pos()):
+                                        agent.agent_id for agent in self.agents.values()}
 
             while len(agent_moves.items()) > 0:
                 moves_copy = agent_moves.copy()
@@ -366,8 +367,8 @@ class MapEnv(MultiAgentEnv):
                     hidden_pos = [hidden_cell[0: 2] for hidden_cell in self.hidden_cells]
                     hidden_char = [hidden_cell[2] for hidden_cell in self.hidden_cells]
                     if move in curr_agent_pos:
-                        # find the agent that is currently at that spot, check where they will be next
-                        # if they're going to move away, go ahead and move into their spot
+                        # find the agent that is currently at that spot, check where they will
+                        # be next if they're going to move away, go ahead and move into their spot
                         conflicting_agent_id = agent_by_pos[tuple(move)]
                         curr_pos = self.agents[agent_id].get_pos().tolist()
                         curr_conflict_pos = self.agents[conflicting_agent_id].get_pos().tolist()
@@ -393,7 +394,6 @@ class MapEnv(MultiAgentEnv):
                                 del agent_moves[agent_id]
                                 del_keys.append(agent_id)
                                 del_keys.append(conflicting_agent_id)
-
 
                     else:
                         new_pos, old_pos = self.agents[agent_id].update_map_agent_pos(move)
@@ -494,7 +494,7 @@ class MapEnv(MultiAgentEnv):
         x += left_pad
         y += top_pad
         view = pad_mat[x - col_size: x + col_size + 1,
-               y - row_size: y + row_size + 1]
+                       y - row_size: y + row_size + 1]
         return view
 
     def pad_if_needed(self, left_edge, right_edge, top_edge, bot_edge, matrix):
@@ -511,8 +511,7 @@ class MapEnv(MultiAgentEnv):
         if bot_edge > col_dim - 1:
             bot_pad = bot_edge - (col_dim - 1)
 
-        return self.pad_matrix(left_pad, right_pad, top_pad, bot_pad, matrix, 0), left_pad, \
-               top_pad
+        return self.pad_matrix(left_pad, right_pad, top_pad, bot_pad, matrix, 0), left_pad, top_pad
 
     def pad_matrix(self, left_pad, right_pad, top_pad, bot_pad, matrix, const_val=1):
         pad_mat = np.pad(matrix, ((left_pad, right_pad), (top_pad, bot_pad)),

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -217,6 +217,7 @@ class TestHarvestEnv(unittest.TestCase):
              [' '] * 3 + ['@'] + [''],
              [' '] * 3 + ['@'] + ['']]
         )
+        np.testing.assert_array_equal(expected_view, agent_view)
 
         # check if if the view is correct if the agent is in the bottom right corner
         self.move_agent(agent_id, [5, 5])
@@ -255,10 +256,10 @@ class TestHarvestEnv(unittest.TestCase):
         self.env.agents['agent-0'].update_map_agent_rot('UP')
         self.env.agents['agent-1'].update_map_agent_rot('UP')
         # test that if an agents firing beam hits another agent it gets covered
-        self.env.update_map({'agent-1': 'FIRE'})
+        self.env.update_custom_moves({'agent-1': 'FIRE'})
         self.env.execute_reservations()
         self.env.update_map_apples([[3, 2]])
-        self.env.update_map({})
+        self.env.update_moves({})
         expected_map = np.array([['@', '@', '@', '@', '@', '@'],
                                  ['@', ' ', ' ', ' ', ' ', '@'],
                                  ['@', ' ', ' ', 'A', 'A', '@'],
@@ -269,10 +270,10 @@ class TestHarvestEnv(unittest.TestCase):
 
         # If an agent is temporarily obscured by a beam, and an apple attempts to spawn there
         # no apple should spawn
-        self.env.update_map({'agent-1': 'FIRE'})
+        self.env.update_custom_moves({'agent-1': 'FIRE'})
         self.env.execute_reservations()
         self.env.update_map_apples([[3, 1]])
-        self.env.update_map({})
+        self.env.update_moves({})
         expected_map = np.array([['@', '@', '@', '@', '@', '@'],
                                  ['@', ' ', ' ', ' ', ' ', '@'],
                                  ['@', ' ', ' ', 'A', 'A', '@'],
@@ -288,105 +289,105 @@ class TestHarvestEnv(unittest.TestCase):
 
         # Test that all the moves and rotations work correctly
         # test when facing left
-        self.env.update_map({agent_id: 'MOVE_LEFT'})
+        self.env.update_moves({agent_id: 'MOVE_LEFT'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 3])
-        self.env.update_map({agent_id: 'MOVE_RIGHT'})
+        self.env.update_moves({agent_id: 'MOVE_RIGHT'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
-        self.env.update_map({agent_id: 'MOVE_UP'})
+        self.env.update_moves({agent_id: 'MOVE_UP'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [1, 2])
-        self.env.update_map({agent_id: 'MOVE_DOWN'})
+        self.env.update_moves({agent_id: 'MOVE_DOWN'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
         # test when facing up
         self.rotate_agent(agent_id, 'UP')
-        self.env.update_map({agent_id: 'MOVE_LEFT'})
+        self.env.update_moves({agent_id: 'MOVE_LEFT'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [1, 2])
-        self.env.update_map({agent_id: 'MOVE_RIGHT'})
+        self.env.update_moves({agent_id: 'MOVE_RIGHT'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
-        self.env.update_map({agent_id: 'MOVE_UP'})
+        self.env.update_moves({agent_id: 'MOVE_UP'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 1])
-        self.env.update_map({agent_id: 'MOVE_DOWN'})
+        self.env.update_moves({agent_id: 'MOVE_DOWN'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
         # test when facing down
         self.rotate_agent(agent_id, 'DOWN')
-        self.env.update_map({agent_id: 'MOVE_LEFT'})
+        self.env.update_moves({agent_id: 'MOVE_LEFT'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [3, 2])
-        self.env.update_map({agent_id: 'MOVE_RIGHT'})
+        self.env.update_moves({agent_id: 'MOVE_RIGHT'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
-        self.env.update_map({agent_id: 'MOVE_UP'})
+        self.env.update_moves({agent_id: 'MOVE_UP'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 3])
-        self.env.update_map({agent_id: 'MOVE_DOWN'})
+        self.env.update_moves({agent_id: 'MOVE_DOWN'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
         # test when facing right
         self.rotate_agent(agent_id, 'RIGHT')
-        self.env.update_map({agent_id: 'MOVE_LEFT'})
+        self.env.update_moves({agent_id: 'MOVE_LEFT'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 1])
-        self.env.update_map({agent_id: 'MOVE_RIGHT'})
+        self.env.update_moves({agent_id: 'MOVE_RIGHT'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
-        self.env.update_map({agent_id: 'MOVE_UP'})
+        self.env.update_moves({agent_id: 'MOVE_UP'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [3, 2])
-        self.env.update_map({agent_id: 'MOVE_DOWN'})
+        self.env.update_moves({agent_id: 'MOVE_DOWN'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
 
         # check that stay works properly
-        self.env.update_map({agent_id: 'STAY'})
+        self.env.update_moves({agent_id: 'STAY'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
         self.assertEqual(self.env.map[2, 2], 'P')
 
         # quick test of stay
-        self.env.update_map({agent_id: 'STAY'})
+        self.env.update_moves({agent_id: 'STAY'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 2])
 
         # if an agent tries to move through a wall they should stay in the same place
         self.rotate_agent(agent_id, 'UP')
         self.move_agent(agent_id, [2, 1])
-        self.env.update_map({agent_id: 'MOVE_UP'})
+        self.env.update_moves({agent_id: 'MOVE_UP'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents[agent_id].get_pos(), [2, 1])
 
         # rotations correctly update the agent state
         self.rotate_agent(agent_id, 'UP')
         # clockwise
-        self.env.update_map({agent_id: 'TURN_CLOCKWISE'})
+        self.env.update_moves({agent_id: 'TURN_CLOCKWISE'})
         self.assertEqual('RIGHT', self.env.agents[agent_id].get_orientation())
-        self.env.update_map({agent_id: 'TURN_CLOCKWISE'})
+        self.env.update_moves({agent_id: 'TURN_CLOCKWISE'})
         self.assertEqual('DOWN', self.env.agents[agent_id].get_orientation())
-        self.env.update_map({agent_id: 'TURN_CLOCKWISE'})
+        self.env.update_moves({agent_id: 'TURN_CLOCKWISE'})
         self.assertEqual('LEFT', self.env.agents[agent_id].get_orientation())
-        self.env.update_map({agent_id: 'TURN_CLOCKWISE'})
+        self.env.update_moves({agent_id: 'TURN_CLOCKWISE'})
         self.assertEqual('UP', self.env.agents[agent_id].get_orientation())
 
         # counterclockwise
-        self.env.update_map({agent_id: 'TURN_COUNTERCLOCKWISE'})
+        self.env.update_moves({agent_id: 'TURN_COUNTERCLOCKWISE'})
         self.assertEqual('LEFT', self.env.agents[agent_id].get_orientation())
-        self.env.update_map({agent_id: 'TURN_COUNTERCLOCKWISE'})
+        self.env.update_moves({agent_id: 'TURN_COUNTERCLOCKWISE'})
         self.assertEqual('DOWN', self.env.agents[agent_id].get_orientation())
-        self.env.update_map({agent_id: 'TURN_COUNTERCLOCKWISE'})
+        self.env.update_moves({agent_id: 'TURN_COUNTERCLOCKWISE'})
         self.assertEqual('RIGHT', self.env.agents[agent_id].get_orientation())
-        self.env.update_map({agent_id: 'TURN_COUNTERCLOCKWISE'})
+        self.env.update_moves({agent_id: 'TURN_COUNTERCLOCKWISE'})
         self.assertEqual('UP', self.env.agents[agent_id].get_orientation())
 
         # test firing
         self.rotate_agent(agent_id, 'UP')
         self.move_agent(agent_id, [3, 2])
-        self.env.update_map({agent_id: 'FIRE'})
+        self.env.update_custom_moves({agent_id: 'FIRE'})
         self.env.execute_reservations()
         agent_view = self.env.agents[agent_id].get_state()
         expected_view = np.array(
@@ -402,7 +403,7 @@ class TestHarvestEnv(unittest.TestCase):
 
         self.rotate_agent(agent_id, 'DOWN')
         self.move_agent(agent_id, [3, 2])
-        self.env.update_map({agent_id: 'FIRE'})
+        self.env.update_custom_moves({agent_id: 'FIRE'})
         self.env.execute_reservations()
         agent_view = self.env.agents[agent_id].get_state()
         expected_view = np.array(
@@ -417,9 +418,9 @@ class TestHarvestEnv(unittest.TestCase):
         self.construct_map(MINI_HARVEST_MAP.copy(), agent_id, [3, 2], 'RIGHT')
         self.env.update_map_apples(self.env.apple_points)
         self.env.execute_reservations()
-        self.env.update_map({agent_id: 'MOVE_RIGHT'})
+        self.env.update_moves({agent_id: 'MOVE_RIGHT'})
         self.env.execute_reservations()
-        self.env.update_map({agent_id: 'MOVE_LEFT'})
+        self.env.update_moves({agent_id: 'MOVE_LEFT'})
         self.env.execute_reservations()
         agent_view = self.env.agents[agent_id].get_state()
         expected_view = np.array(
@@ -441,7 +442,7 @@ class TestHarvestEnv(unittest.TestCase):
         self.env.agents['agent-0'].update_map_agent_rot('UP')
         self.env.agents['agent-1'].update_map_agent_rot('UP')
         # walk over an apple
-        self.env.update_map({'agent-0': 'MOVE_DOWN',
+        self.env.update_moves({'agent-0': 'MOVE_DOWN',
                              'agent-1': 'MOVE_DOWN'})
         self.env.execute_reservations()
         reward_0 = self.env.agents['agent-0'].compute_reward()
@@ -450,7 +451,7 @@ class TestHarvestEnv(unittest.TestCase):
         self.assertTrue(reward_1 == 1)
         # fire a beam from agent 1 to 2
         self.env.agents['agent-1'].update_map_agent_rot('LEFT')
-        self.env.update_map({'agent-1': 'FIRE'})
+        self.env.update_custom_moves({'agent-1': 'FIRE'})
         self.env.execute_reservations()
         reward_0 = self.env.agents['agent-0'].compute_reward()
         reward_1 = self.env.agents['agent-1'].compute_reward()
@@ -466,19 +467,29 @@ class TestHarvestEnv(unittest.TestCase):
         np.testing.assert_array_equal(self.env.base_map, self.env.map)
 
         # test that agents can't walk into other agents
-        self.env.agents['agent-0'].update_map_agent_pos([3, 3])
-        self.env.agents['agent-1'].update_map_agent_pos([3, 4])
+        self.env.reserved_slots.append([3, 3, 'P', 'agent-0'])
+        self.env.reserved_slots.append([3, 4, 'P', 'agent-1'])
         self.env.agents['agent-0'].update_map_agent_rot('UP')
         self.env.agents['agent-1'].update_map_agent_rot('UP')
-        self.env.update_map({'agent-0': 'MOVE_DOWN'})
         self.env.execute_reservations()
-        self.env.update_map({'agent-1': 'MOVE_UP'})
+        self.env.update_moves({'agent-0': 'MOVE_DOWN'})
+        self.env.execute_reservations()
+        self.env.update_moves({'agent-1': 'MOVE_UP'})
+        self.env.execute_reservations()
+        np.testing.assert_array_equal(self.env.agents['agent-0'].get_pos(), [3, 3])
+        np.testing.assert_array_equal(self.env.agents['agent-1'].get_pos(), [3, 4])
+
+        # test that agents can't walk through each other
+        self.env.update_moves({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_UP'})
         self.env.execute_reservations()
         np.testing.assert_array_equal(self.env.agents['agent-0'].get_pos(), [3, 3])
         np.testing.assert_array_equal(self.env.agents['agent-1'].get_pos(), [3, 4])
 
         # test that if an agents firing beam hits another agent it gets covered
-        self.env.update_map({'agent-0': 'MOVE_UP', 'agent-1': 'FIRE'})
+        self.env.update_moves({'agent-0': 'MOVE_UP'})
+        self.env.execute_reservations()
+        self.env.clean_map()
+        self.env.update_custom_moves({'agent-1': 'FIRE'})
         self.env.execute_reservations()
         expected_map = np.array([['@', '@', '@', '@', '@', '@'],
                                  ['@', ' ', ' ', ' ', ' ', '@'],
@@ -488,7 +499,7 @@ class TestHarvestEnv(unittest.TestCase):
                                  ['@', '@', '@', '@', '@', '@']])
         np.testing.assert_array_equal(expected_map, self.env.map)
         # but by the next step, the agent is visible again
-        self.env.update_map({})
+        self.env.clean_map()
         self.env.execute_reservations()
         expected_map = np.array([['@', '@', '@', '@', '@', '@'],
                                  ['@', ' ', ' ', ' ', ' ', '@'],
@@ -498,19 +509,48 @@ class TestHarvestEnv(unittest.TestCase):
                                  ['@', '@', '@', '@', '@', '@']])
         np.testing.assert_array_equal(expected_map, self.env.map)
 
+        # test that if two agents fire on each other than they're still there after
+        self.env.agents['agent-0'].update_map_agent_rot('DOWN')
+        self.env.update_custom_moves({'agent-0': 'FIRE', 'agent-1': 'FIRE'})
+        self.env.execute_reservations()
+        self.env.clean_map()
+        expected_map = np.array([['@', '@', '@', '@', '@', '@'],
+                                 ['@', ' ', ' ', ' ', ' ', '@'],
+                                 ['@', ' ', ' ', 'A', 'A', '@'],
+                                 ['@', ' ', 'P', ' ', 'P', '@'],
+                                 ['@', ' ', ' ', 'A', ' ', '@'],
+                                 ['@', '@', '@', '@', '@', '@']])
+        np.testing.assert_array_equal(expected_map, self.env.map)
+
         # test that agents can walk into other agents if moves are de-conflicting
-        self.env.update_map({'agent-0': 'MOVE_DOWN'})
-        self.env.execute_reservations()
-        self.env.update_map({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_LEFT'})
-        self.env.execute_reservations()
+        # this is only set of stochastically so try it 50 times
+        for i in range(100):
+            self.env.agents['agent-0'].update_map_agent_rot('UP')
+            self.env.update_moves({'agent-0': 'MOVE_DOWN'})
+            self.env.execute_reservations()
+            self.env.update_moves({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_LEFT'})
+            self.env.execute_reservations()
+            expected_map = np.array([['@', '@', '@', '@', '@', '@'],
+                                     ['@', ' ', ' ', ' ', ' ', '@'],
+                                     ['@', ' ', ' ', 'A', 'P', '@'],
+                                     ['@', ' ', ' ', ' ', 'P', '@'],
+                                     ['@', ' ', ' ', 'A', ' ', '@'],
+                                     ['@', '@', '@', '@', '@', '@']])
+            try:
+                np.testing.assert_array_equal(expected_map, self.env.map)
+            except:
+                import ipdb; ipdb.set_trace()
+            self.env.update_moves({'agent-0': 'MOVE_UP', 'agent-1': 'MOVE_RIGHT'})
+            self.env.execute_reservations()
 
         # test that if two agents have a conflicting move then the tie is broken randomly
         num_agent_1 = 0.0
         num_agent_2 = 0.0
         for i in range(5000):
-            self.env.agents['agent-0'].update_map_agent_pos([3, 2])
-            self.env.agents['agent-1'].update_map_agent_pos([3, 4])
-            self.env.update_map({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_UP'})
+            self.env.reserved_slots.append([3, 2, 'P', 'agent-0'])
+            self.env.reserved_slots.append([3, 4, 'P', 'agent-1'])
+            self.env.execute_reservations()
+            self.env.update_moves({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_UP'})
             self.env.execute_reservations()
             if self.env.agents['agent-0'].get_pos().tolist() == [3, 3]:
                 num_agent_1 += 1
@@ -525,10 +565,11 @@ class TestHarvestEnv(unittest.TestCase):
         num_agent_1 = 0.0
         other_agents = 0.0
         for i in range(10000):
-            self.env.agents['agent-0'].update_map_agent_pos([3, 2])
-            self.env.agents['agent-1'].update_map_agent_pos([3, 4])
-            self.env.agents['agent-2'].update_map_agent_pos([2, 3])
-            self.env.update_map({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_UP',
+            self.env.reserved_slots.append([3, 2, 'P', 'agent-0'])
+            self.env.reserved_slots.append([3, 4, 'P', 'agent-1'])
+            self.env.reserved_slots.append([2, 3, 'P', 'agent-2'])
+            self.env.execute_reservations()
+            self.env.update_moves({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_UP',
                                  'agent-2': 'MOVE_RIGHT'})
 
             self.env.execute_reservations()
@@ -546,12 +587,13 @@ class TestHarvestEnv(unittest.TestCase):
         self.env.reset()
 
         # test that agents can't walk into other agents
-        self.env.agents['agent-0'].update_map_agent_pos([4, 2])
-        self.env.agents['agent-1'].update_map_agent_pos([4, 4])
+        self.env.reserved_slots.append([4, 2, 'P', 'agent-0'])
+        self.env.reserved_slots.append([4, 4, 'P', 'agent-1'])
         self.env.agents['agent-0'].update_map_agent_rot('UP')
         self.env.agents['agent-1'].update_map_agent_rot('UP')
+        self.env.execute_reservations()
         # test that if an agents firing beam hits another agent it gets covered
-        self.env.update_map({'agent-1': 'FIRE'})
+        self.env.update_custom_moves({'agent-1': 'FIRE'})
         self.env.execute_reservations()
         expected_map = np.array([['@', '@', '@', '@', '@', '@'],
                                  ['@', ' ', ' ', ' ', ' ', '@'],
@@ -560,7 +602,7 @@ class TestHarvestEnv(unittest.TestCase):
                                  ['@', 'F', 'F', 'F', 'P', '@'],
                                  ['@', '@', '@', '@', '@', '@']])
         np.testing.assert_array_equal(expected_map, self.env.map)
-        self.env.update_map({})
+        self.env.update_moves({})
         expected_map = np.array([['@', '@', '@', '@', '@', '@'],
                                  ['@', ' ', ' ', ' ', ' ', '@'],
                                  ['@', ' ', ' ', 'A', 'A', '@'],
@@ -576,9 +618,14 @@ class TestHarvestEnv(unittest.TestCase):
     def add_agent(self, agent_id, start_pos, start_orientation, env, view_len):
         self.env.agents[agent_id] = HarvestAgent(agent_id, start_pos, start_orientation,
                                                  env, view_len)
+        # FIXME(ev) just for now
+        char = self.env.map[start_pos[0], start_pos[1]]
+        self.env.hidden_cells.append([start_pos[0], start_pos[1], char])
+        self.env.map[start_pos[0], start_pos[1]] = 'P'
 
     def move_agent(self, agent_id, new_pos):
-        self.env.agents[agent_id].update_map_agent_pos(new_pos)
+        self.env.reserved_slots.append([new_pos[0], new_pos[1], 'P', agent_id])
+        self.env.execute_reservations()
 
     def rotate_agent(self, agent_id, new_rot):
         self.env.agents[agent_id].update_map_agent_rot(new_rot)
@@ -587,12 +634,9 @@ class TestHarvestEnv(unittest.TestCase):
         # overwrite the map for testing
         self.env = HarvestEnv(map, num_agents=0)
         self.env.reset()
-        self.clear_agents()
 
         # replace the agents with agents with smaller views
         self.add_agent(agent_id, start_pos, start_orientation, self.env, 2)
-        # TODO(ev) hack for now, can't call render logic or else it will spawn apples
-        self.move_agent(agent_id, start_pos)
 
 
 class TestCleanupEnv(unittest.TestCase):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -593,12 +593,10 @@ class TestHarvestEnv(unittest.TestCase):
             self.env.update_moves({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_UP',
                                    'agent-2': 'MOVE_RIGHT'})
             self.env.execute_reservations()
-            import ipdb; ipdb.set_trace()
             if self.env.agents['agent-2'].get_pos().tolist() == [2, 2]:
                 percent_failed += 1
             else:
                 percent_accomplished += 1
-        import ipdb; ipdb.set_trace()
         percent_success = percent_accomplished / (percent_accomplished + percent_failed)
         within_bounds = (.45 < percent_success) and (percent_success < .55)
         self.assertTrue(within_bounds)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -444,7 +444,7 @@ class TestHarvestEnv(unittest.TestCase):
         self.env.agents['agent-1'].update_map_agent_rot('UP')
         # walk over an apple
         self.env.update_moves({'agent-0': 'MOVE_DOWN',
-                             'agent-1': 'MOVE_DOWN'})
+                               'agent-1': 'MOVE_DOWN'})
         self.env.execute_reservations()
         reward_0 = self.env.agents['agent-0'].compute_reward()
         reward_1 = self.env.agents['agent-1'].compute_reward()
@@ -570,7 +570,7 @@ class TestHarvestEnv(unittest.TestCase):
             self.env.reserved_slots.append([2, 3, 'P', 'agent-2'])
             self.env.execute_reservations()
             self.env.update_moves({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_UP',
-                                 'agent-2': 'MOVE_RIGHT'})
+                                   'agent-2': 'MOVE_RIGHT'})
 
             self.env.execute_reservations()
             if self.env.agents['agent-2'].get_pos().tolist() == [3, 3]:

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -590,11 +590,10 @@ class TestHarvestEnv(unittest.TestCase):
             self.env.reserved_slots.append([3, 4, 'P', 'agent-1'])
             self.env.reserved_slots.append([2, 2, 'P', 'agent-2'])
             self.env.execute_reservations()
-            import ipdb; ipdb.set_trace()
             self.env.update_moves({'agent-0': 'MOVE_DOWN', 'agent-1': 'MOVE_UP',
                                    'agent-2': 'MOVE_RIGHT'})
-
             self.env.execute_reservations()
+            import ipdb; ipdb.set_trace()
             if self.env.agents['agent-2'].get_pos().tolist() == [2, 2]:
                 percent_failed += 1
             else:


### PR DESCRIPTION
- major refactor, map_env subclasses now only need to define what a hidden cell is to be replaced with
- this makes implementing cleanup much easier
- also, pulled some common methods into map_env
- fixed a bug where sequences of conflicts between agents could cause an error(i.e. agent 0 at 2, 3 and agent 1 at 4, 3 both want to move to 3,3 while agent 2 wants to move to 2,3. If agent 0 succeeded at its move, agent 2 would still be blocked). 