### PR TITLE
Fix for waste spawning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,11 +7,10 @@ dependencies:
         - gym==0.10.5
         - matplotlib==3.0.2
         - opencv-python
-        - ray==0.6.0
+        - ray==0.6.1
         - tensorflow==1.12.0
         - scipy==1.2.0
         - setproctitle
         - psutil
         - lz4
-        - ray==0.6.0
 

--- a/rollout.py
+++ b/rollout.py
@@ -14,7 +14,7 @@ from social_dilemmas.envs.harvest import HarvestEnv
 FLAGS = tf.app.flags.FLAGS
 
 tf.app.flags.DEFINE_string(
-    'vid_path', '/home/natasha/Dropbox (MIT)/Projects/AgentEmpathy/vids',
+    'vid_path', os.path.abspath(os.path.join(os.path.dirname(__file__), './videos')),
     'Path to directory where videos are saved.')
 tf.app.flags.DEFINE_string(
     'env', 'cleanup',

--- a/social_dilemmas/envs/cleanup.py
+++ b/social_dilemmas/envs/cleanup.py
@@ -144,16 +144,20 @@ class CleanupEnv(MapEnv):
                 rand_num = np.random.rand(1)[0]
                 if rand_num < self.current_apple_spawn_prob:
                     spawn_points.append((row, col, 'A'))
-        for i in range(len(self.waste_points)):
-            row, col = self.waste_points[i]
-            if self.map[row, col] != 'P' and self.map[row, col] != 'H':
-                rand_num = np.random.rand(1)[0]
-                if rand_num < self.current_waste_spawn_prob:
-                    spawn_points.append((row, col, 'H'))
+
+        # spawn one waste point
+        if not np.isclose(self.current_waste_spawn_prob, 0):
+            while True:
+                spawn_index = np.random.randint(0, len(self.waste_points))
+                row, col = self.waste_points[spawn_index]
+                if self.map[row, col] != 'P' and self.map[row, col] != 'H':
+                    rand_num = np.random.rand(1)[0]
+                    if rand_num < self.current_waste_spawn_prob:
+                        spawn_points.append((row, col, 'H'))
+                        break
         return spawn_points
 
     def compute_probabilities(self):
-        # TODO(ev) there is almost certainly a bug here
         waste_density = 1 - self.compute_permitted_area() / self.potential_waste_area
         if waste_density >= thresholdDepletion:
             self.current_apple_spawn_prob = 0


### PR DESCRIPTION
Previously all the waste cells were assessed for spawning. We only check one now. Additionally, the path for generating videos is no longer hardcoded.

Closes #78, #89