### PR TITLE
refactor, bug: refactored the environments to separate the map of the world from the agent positions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,45 +36,23 @@ Next, go to the rllib folder:
 Tests are located in the test folder and can be run individually or run by running `python -m pytest`
 
 # Constructing new environments
-The key parameter of MapEnv is reserved slots; env.reserved_slots stores tuples of length three or four 
-consisting (row, col, 'char') where char is the character you wish to place 
-Every environment that subclasses MapEnv needs to implement the following methods
+Every environment that subclasses MapEnv probably needs to implement the following methods
 
 ```
-  def custom_reset(self):
-      """Reset custom elements of the map. For example, spawn apples and build walls"""  
-      pass
+    def custom_reset(self):
+        """Reset custom elements of the map. For example, spawn apples"""
+        pass
 
-  def custom_action(self, agent):
-      """Add reservations to self.reserved_slots for actions that are not move or turn. For example,  
-      if an agent can fire, you can add (row, col, 'F') to indicate that F should be placed at that point"""
-      pass
+    def custom_action(self, agent, action):
+        """Execute any custom, non-move actions that may be defined, like fire or clean"""
+        pass
 
-  def custom_map_update(self):
-      """Custom map updates that don't have to do with agent actions. For example, you can add
-      (row, col, 'A') to env.reserved_slots to indicate an apple should be placed at that point"""
-      pass
+    def custom_map_update(self):
+        """Custom map updates that don't have to do with agent actions"""
+        pass
 
-  def append_hiddens(self, new_pos, old_char, new_char):
-      """Add cells that will be hidden and should be put back later
-
-      Parameters
-      ----------
-      new_pos: list
-          the position the new char is going to be placed at
-      old_char: str
-          the character that will be hidden
-      new_char: str
-          the character that will replace it
-      """
-      raise NotImplementedError
-
-   def execute_custom_reservations(self):
-    """Execute reserved slots that do not have to do with moving agents. For example, placing apples 
-       or placing the fired beam. """
-    raise NotImplementedError
-
-  def setup_agents(self):
-      """Construct all the agents for the environment"""
+    def setup_agents(self):
+        """Construct all the agents for the environment"""
+        raise NotImplementedError
 ```
         

--- a/rollout.py
+++ b/rollout.py
@@ -7,7 +7,6 @@ import os
 import sys
 import shutil
 import tensorflow as tf
-import time
 
 from social_dilemmas.envs.cleanup import CleanupEnv
 from social_dilemmas.envs.harvest import HarvestEnv
@@ -56,12 +55,11 @@ class Controller(object):
         """
         rewards = []
         observations = []
-        shape = self.env.map.shape
+        shape = self.env.world_map.shape
         full_obs = [np.zeros(
             (shape[0], shape[1], 3), dtype=np.uint8) for i in range(horizon)]
 
         for i in range(horizon):
-            time_start = time.time()
             agents = list(self.env.agents.values())
             action_dim = agents[0].action_space.n
             rand_action = np.random.randint(action_dim, size=5)
@@ -70,29 +68,16 @@ class Controller(object):
                                                     'agent-2': rand_action[2],
                                                     'agent-3': rand_action[3],
                                                     'agent-4': rand_action[4]})
-            print('STEP TIME IS', time.time() - time_start)
 
-            print("timestep", i, "action", rand_action, "reward", rew['agent-0'])
-            time0 = time.time()
             sys.stdout.flush()
-            time1 = time.time()
-            print('flush time is ', time1 - time0)
 
             if save_path is not None:
                 self.env.render(filename=save_path + 'frame' + str(i).zfill(6) + '.png')
-
-            time2 = time.time()
-            print('Save and render time is ', time2 - time1)
 
             rgb_arr = self.env.map_to_colors()
             full_obs[i] = rgb_arr.astype(np.uint8)
             observations.append(obs['agent-0'])
             rewards.append(rew['agent-0'])
-            time3 = time.time()
-            print('Mapping to color time is ', time3 - time2)
-
-            time_final = time.time()
-            print('total time of a step is ', time_final - time_start)
 
         return rewards, observations, full_obs
 

--- a/social_dilemmas/envs/harvest.py
+++ b/social_dilemmas/envs/harvest.py
@@ -2,9 +2,8 @@ import numpy as np
 
 from social_dilemmas.envs.agent import HarvestAgent, HARVEST_VIEW_SIZE
 from social_dilemmas.constants import HARVEST_MAP
-from social_dilemmas.envs.map_env import MapEnv, ACTIONS, ORIENTATIONS
+from social_dilemmas.envs.map_env import MapEnv, ACTIONS
 import utility_funcs as util
-
 
 APPLE_RADIUS = 2
 
@@ -18,10 +17,6 @@ class HarvestEnv(MapEnv):
 
     def __init__(self, ascii_map=HARVEST_MAP, num_agents=1, render=False):
         super().__init__(ascii_map, num_agents, render)
-        # FIXME(ev) this is a temporary way to prevent agent views
-        # FIXME(ev) from hiding firing beams
-        self.no_update_cells = ['F']
-        self.firing_points = []
         self.apple_points = []
         for row in range(self.base_map.shape[0]):
             for col in range(self.base_map.shape[1]):
@@ -35,11 +30,9 @@ class HarvestEnv(MapEnv):
 
     @property
     def observation_space(self):
-        # FIXME(ev) this is an information leak
         agents = list(self.agents.values())
         return agents[0].observation_space
 
-    # TODO(ev) this can probably be moved into the superclass
     def setup_agents(self):
         map_with_agents = self.get_map_with_agents()
 
@@ -54,46 +47,22 @@ class HarvestEnv(MapEnv):
 
     def custom_reset(self):
         """Initialize the walls and the apples"""
-        self.firing_points = []
-        self.update_map_apples(self.apple_points)
+        for apple_point in self.apple_points:
+            self.world_map[apple_point[0], apple_point[1]] = 'A'
 
     def custom_action(self, agent, action):
-        agent.fire_beam()
-        self.reserved_slots += self.update_map_fire(agent.get_pos().tolist(),
-                                                    agent.get_orientation())
+        agent.fire_beam('F')
+        beam_pos, updates = self.update_map_fire(agent.get_pos().tolist(),
+                                                 agent.get_orientation(), ACTIONS['FIRE'],
+                                                 'F', [], [])
+        self.beam_pos += beam_pos
+        return updates
 
     def custom_map_update(self):
         "See parent class"
         # spawn the apples
         new_apples = self.spawn_apples()
-        if len(new_apples) > 0:
-            self.reserved_slots += new_apples
-
-    def execute_custom_reservations(self):
-        """Execute firing and then apple spawning"""
-        apple_pos = []
-        firing_pos = []
-        for slot in self.reserved_slots:
-            row, col = slot[0], slot[1]
-            if slot[2] == 'A':
-                apple_pos.append([row, col])
-            elif slot[2] == 'F':
-                firing_pos.append([row, col])
-        for pos in firing_pos:
-            row, col = pos
-            self.map[row, col] = 'F'
-
-        # update the apples
-        self.update_map_apples(apple_pos)
-
-    def append_hiddens(self, new_pos, old_char, new_char=None):
-        """Add hidden cells to self.hidden_cells that should be put back when cleaning"""
-        # an apple is gone once an agent walks over it
-
-        if old_char == 'A' and new_char == 'P':
-            self.hidden_cells.append(new_pos + [' '])
-        else:
-            self.hidden_cells.append(new_pos + [old_char])
+        self.update_map(new_apples)
 
     def spawn_apples(self):
         """Construct the apples spawned in this step.
@@ -107,8 +76,10 @@ class HarvestEnv(MapEnv):
         new_apple_points = []
         for i in range(len(self.apple_points)):
             row, col = self.apple_points[i]
-            if self.map[row, col] != 'P' and self.map[row, col] != 'A':
-                window = util.return_view(self.map, self.apple_points[i], APPLE_RADIUS, APPLE_RADIUS)
+            # apples can't spawn where agents are standing or where an apple already is
+            if [row, col] not in self.agent_pos and self.world_map[row, col] != 'A':
+                window = util.return_view(self.world_map, self.apple_points[i],
+                                          APPLE_RADIUS, APPLE_RADIUS)
                 num_apples = self.count_apples(window)
                 spawn_prob = SPAWN_PROB[min(num_apples, 3)]
                 rand_num = np.random.rand(1)[0]
@@ -122,34 +93,3 @@ class HarvestEnv(MapEnv):
         counts_dict = dict(zip(unique, counts))
         num_apples = counts_dict.get('A', 0)
         return num_apples
-
-    def update_map_apples(self, new_apple_points):
-        curr_agent_pos = [agent.get_pos().tolist() for agent in self.agents.values()]
-        for i in range(len(new_apple_points)):
-            row, col = new_apple_points[i]
-            if self.map[row, col] != 'P' and self.map[row, col] != 'F':
-                self.map[row, col] = 'A'
-            # you can't spawn apples if an agent is there but hidden by a beam,
-            elif self.map[row, col] == 'F' and [row, col] not in curr_agent_pos:
-                self.append_hiddens([row, col], 'A')
-
-    def update_map_fire(self, firing_pos, firing_orientation):
-        num_fire_cells = ACTIONS['FIRE']
-        start_pos = np.asarray(firing_pos)
-        firing_direction = ORIENTATIONS[firing_orientation]
-        # compute the other two starting positions
-        right_shift = self.rotate_right(firing_direction)
-        firing_pos = [start_pos, start_pos + right_shift - firing_direction,
-                      start_pos - right_shift - firing_direction]
-        firing_points = []
-        for pos in firing_pos:
-            for i in range(num_fire_cells):
-                next_cell = pos + firing_direction
-                if self.test_if_in_bounds(next_cell) and self.map[next_cell[0], next_cell[1]] != '@':
-                    char = self.map[next_cell[0], next_cell[1]]
-                    self.append_hiddens([next_cell[0], next_cell[1]], char, 'F')
-                    firing_points.append((next_cell[0], next_cell[1], 'F'))
-                    pos += firing_direction
-                else:
-                    break
-        return firing_points

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -3,6 +3,7 @@
 import unittest
 
 import numpy as np
+import random
 
 from gym.spaces import Discrete
 from social_dilemmas.envs.agent import Agent
@@ -905,7 +906,6 @@ class TestHarvestEnv(unittest.TestCase):
         np.testing.assert_array_equal(expected_map, self.env.test_map)
 
     def clear_agents(self):
-        # FIXME(ev) this doesn't clear agent positions off the board
         self.env.agents = {}
 
     def add_agent(self, agent_id, start_pos, start_orientation, env, view_len):
@@ -1004,7 +1004,9 @@ class TestCleanupEnv(unittest.TestCase):
 
         # check that you can clean up waste that an agent is standing on
         self.move_agent('agent-1', [2, 2])
-        self.rotate_agent('agent-0', 'UP')
+        self.move_agent('agent-0', [1, 3])
+        self.rotate_agent('agent-0', 'RIGHT')
+        random.seed(6)
         self.env.step({'agent-0': CLEANUP_ACTION_MAP['CLEAN']})
         self.assertTrue(self.env.world_map[2, 2] == 'R')
 
@@ -1099,8 +1101,10 @@ class TestCleanupEnv(unittest.TestCase):
         self.assertTrue(np.isclose(self.env.current_apple_spawn_prob, 0.1))
 
         # test that you can spawn waste under an agent
-        self.move_agent('agent-0', [3, 2])
-        self.assertTrue(self.env.world_map[3, 2] == 'H')
+        self.move_agent('agent-0', [2, 2])
+        random.seed(2)
+        self.env.step({})
+        self.assertTrue(self.env.world_map[2, 2] == 'H')
 
     def clear_agents(self):
         self.env.agents = {}


### PR DESCRIPTION
In the current code base the map of the world and the agent positions are tracked on the same map. As a consequence, whenever an agent covers a position we have to keep track of what is being covered. This leads to a lot of unnecessary code. Agent positions are now tracked by the agents and the map of the world is kept in a variable called world_map. 

Resolves #83 This is written
Resolves #82 This is written
Resolves #111 These are written
Resolves #110 It is based on underlying map state which is now done correctly now
Resolves #112 These tests are written
Resolves #117 hidden_cells is removed
Resolves #121 this PR just does this
Resolves #119 by getting rid of the reservation objects
Resolves #108 by getting rid of hidden cells