### PR TITLE
bug(map_env.py): agents walking into walls wasnt checked

### DIFF
--- a/social_dilemmas/envs/agent.py
+++ b/social_dilemmas/envs/agent.py
@@ -102,6 +102,17 @@ class Agent(object):
     def get_map(self):
         return self.grid
 
+    def get_next_pos(self, new_pos):
+        old_pos = self.get_pos()
+        ego_new_pos = self.translate_pos_to_egocentric_coord(new_pos)
+        new_row, new_col = ego_new_pos
+        # you can't walk through walls
+        temp_pos = new_pos.copy()
+        if self.grid[new_row, new_col] == '@':
+            temp_pos = self.get_pos()
+
+        return temp_pos
+
     def update_agent_pos(self, new_pos):
         """Updates the agents internal positions
 
@@ -116,10 +127,11 @@ class Agent(object):
         ego_new_pos = self.translate_pos_to_egocentric_coord(new_pos)
         new_row, new_col = ego_new_pos
         # you can't walk through walls
+        temp_pos = new_pos.copy()
         if self.grid[new_row, new_col] == '@':
-            new_pos = self.get_pos()
+            temp_pos = self.get_pos()
 
-        self.set_pos(new_pos)
+        self.set_pos(temp_pos)
         # TODO(ev) list array consistency
         return self.get_pos(), np.array(old_pos)
 

--- a/social_dilemmas/envs/agent.py
+++ b/social_dilemmas/envs/agent.py
@@ -103,7 +103,6 @@ class Agent(object):
         return self.grid
 
     def get_next_pos(self, new_pos):
-        old_pos = self.get_pos()
         ego_new_pos = self.translate_pos_to_egocentric_coord(new_pos)
         new_row, new_col = ego_new_pos
         # you can't walk through walls

--- a/social_dilemmas/envs/map_env.py
+++ b/social_dilemmas/envs/map_env.py
@@ -360,6 +360,8 @@ class MapEnv(MultiAgentEnv):
                 # rotate the selected action appropriately
                 rot_action = self.rotate_action(selected_action, agent.get_orientation())
                 new_pos = agent.get_pos() + rot_action
+                # allow the agents to confirm what position they can move to
+                new_pos = agent.get_next_pos(new_pos)
                 reserved_slots.append((*new_pos, 'P', agent_id))
             elif 'TURN' in action:
                 new_rot = self.update_rotation(action, agent.get_orientation())
@@ -449,6 +451,8 @@ class MapEnv(MultiAgentEnv):
                                             .get_pos().tolist():
                                         conflict_cell_free = False
 
+                        # if the conflict cell is open, let one of the conflicting agents
+                        # move into it
                         if conflict_cell_free:
                             self.agents[agent_to_slot[index]].update_agent_pos(move)
                             agent_by_pos = {tuple(agent.get_pos()):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -657,6 +657,18 @@ class TestMapEnv(unittest.TestCase):
         self.assertTrue(self.env.agents['agent-2'].get_pos().tolist() == [2, 3])
         self.assertTrue(self.env.agents['agent-3'].get_pos().tolist() == [3, 2])
 
+        # do a check that the conflict resolution still works right
+        # if one of the agents is trying to walk through a wall
+        self.move_agent('agent-0', [2, 1])
+        self.move_agent('agent-1', [1, 1])
+        # move these agent out of the way
+        self.move_agent('agent-2', [4, 4])
+        self.move_agent('agent-3', [3, 3])
+        curr_map = self.env.test_map.copy()
+        self.env.step({'agent-0': ACTION_MAP['MOVE_UP'],
+                       'agent-1': ACTION_MAP['MOVE_RIGHT']})
+        np.testing.assert_array_equal(self.env.test_map, curr_map)
+
     def move_agent(self, agent_id, new_pos):
         self.env.agents[agent_id].update_agent_pos(new_pos)
         map_with_agents = self.env.get_map_with_agents()


### PR DESCRIPTION
In map_envs resolution mechanism, conflicts were checked
against the moves agents intended to take. Not all of these moves were possible, say, if an agent was moving into a wall. Also added a test for this case.