### PR TITLE
bug(cleanup.py): probability computation did not perfectly match original env

### DIFF
--- a/social_dilemmas/envs/cleanup.py
+++ b/social_dilemmas/envs/cleanup.py
@@ -154,8 +154,9 @@ class CleanupEnv(MapEnv):
             if waste_density <= thresholdRestoration:
                 self.current_apple_spawn_prob = appleRespawnProbability
             else:
-                coeff = appleRespawnProbability / (thresholdDepletion - thresholdRestoration)
-                spawn_prob = (1 - (waste_density - thresholdRestoration)) * coeff
+                spawn_prob = (1 - (waste_density - thresholdRestoration)
+                              / (thresholdDepletion - thresholdRestoration)) \
+                             * appleRespawnProbability
                 self.current_apple_spawn_prob = spawn_prob
 
     def compute_permitted_area(self):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1116,7 +1116,7 @@ class TestCleanupEnv(unittest.TestCase):
             if self.env.compute_permitted_area() == 4:
                 break
         self.env.compute_probabilities()
-        self.assertTrue(np.isclose(self.env.current_apple_spawn_prob, 0.1))
+        self.assertTrue(np.isclose(self.env.current_apple_spawn_prob, 0.025))
 
         # test that you can spawn waste under an agent
         self.move_agent('agent-0', [3, 2])


### PR DESCRIPTION
the computation probability was mistakenly:
                spawn_prob = (1 - (waste_density - thresholdRestoration))
                              / (thresholdDepletion - thresholdRestoration) \
                             * appleRespawnProbability

instead of  
spawn_prob = (1 - (waste_density - thresholdRestoration)
                              / (thresholdDepletion - thresholdRestoration)) \
                             * appleRespawnProbability