### PR TITLE
Removed double ray requirement in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ tensorflow-gpu==1.12.0
 termcolor==1.1.0
 urllib3==1.24.1
 Werkzeug==0.14.1
+setproctitle==1.1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ pytest==4.1.1
 python-dateutil==2.7.5
 ray==0.6.4
 PyYAML==4.2b1
-ray==0.6.1
 redis==3.0.1
 requests==2.21.0
 scipy==1.2.0


### PR DESCRIPTION
Please check whether the correct ray version has been removed.
Both 0.6.4 and 0.6.1 were present, so I removed the older one - this might not be correct.