### PR TITLE
Consistency entropy sign after breaking Ray update (6.5)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ pytest==4.1.1
 python-dateutil==2.7.5
 ray==0.6.4
 PyYAML==4.2b1
-ray==0.6.1
 redis==3.0.1
 requests==2.21.0
 scipy==1.2.0
@@ -45,3 +44,4 @@ tensorflow-gpu==1.12.0
 termcolor==1.1.0
 urllib3==1.24.1
 Werkzeug==0.14.1
+setproctitle==1.1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ pyglet==1.3.2
 pyparsing==2.3.1
 pytest==4.1.1
 python-dateutil==2.7.5
-ray==0.6.4
+ray==0.6.6
 PyYAML==4.2b1
 redis==3.0.1
 requests==2.21.0

--- a/run_scripts/train_a3c_influence.py
+++ b/run_scripts/train_a3c_influence.py
@@ -132,7 +132,7 @@ def setup(env, hparams, num_cpus, num_gpus, num_agents, use_gpus_for_workers=Fal
             "num_cpus_for_driver": cpus_for_driver,
             "num_gpus_per_worker": num_gpus_per_worker,  # Can be a fraction
             "num_cpus_per_worker": num_cpus_per_worker,  # Can be a fraction
-            "entropy_coeff": tune.grid_search([0, -1e-1]),
+            "entropy_coeff": tune.grid_search([0, 1e-1]),
             "multiagent": {
                 "policy_graphs": policy_graphs,
                 "policy_mapping_fn": tune.function(policy_mapping_fn),

--- a/run_scripts/train_a3c_moa.py
+++ b/run_scripts/train_a3c_moa.py
@@ -23,7 +23,7 @@ tf.app.flags.DEFINE_integer(
     'num_agents', 5,
     'Number of agent policies')
 tf.app.flags.DEFINE_integer(
-    'num_cpus', 8,
+    'num_cpus', 17,
     'Number of available CPUs')
 tf.app.flags.DEFINE_integer(
     'num_gpus', 0,
@@ -38,7 +38,7 @@ tf.app.flags.DEFINE_float(
     'num_workers_per_device', 1,
     'Number of workers to place on a single device (CPU or GPU)')
 tf.app.flags.DEFINE_boolean(
-    'tune', False,
+    'tune', True,
     'Set to true to do hyperparameter tuning.')
 tf.app.flags.DEFINE_boolean(
     'debug', False,
@@ -178,7 +178,7 @@ def main(unused_argv):
     # else:
     #     ray.init(num_cpus=FLAGS.num_cpus, object_store_memory=int(25e10),
     #              redis_max_memory=int(50e10))
-    ray.init()
+    ray.init(redis_address="localhost:6379")
     if FLAGS.env == 'harvest':
         hparams = harvest_default_params
     else:
@@ -204,6 +204,7 @@ def main(unused_argv):
             },
             'checkpoint_freq': 100,
             "config": config,
+            'upload_dir': 's3://njaques.experiments/fourth_reproduction/a3c_causal_moa_cleanup'
         }
     }, resume=FLAGS.resume)
 

--- a/run_scripts/train_a3c_moa.py
+++ b/run_scripts/train_a3c_moa.py
@@ -132,7 +132,7 @@ def setup(env, hparams, num_cpus, num_gpus, num_agents, use_gpus_for_workers=Fal
             "num_cpus_for_driver": cpus_for_driver,
             "num_gpus_per_worker": num_gpus_per_worker,  # Can be a fraction
             "num_cpus_per_worker": num_cpus_per_worker,  # Can be a fraction
-            "entropy_coeff": tune.grid_search([0, -1e-1, -1e-2]),
+            "entropy_coeff": tune.grid_search([0, 1e-1, 1e-2]),
             "multiagent": {
                 "policy_graphs": policy_graphs,
                 "policy_mapping_fn": tune.function(policy_mapping_fn),

--- a/run_scripts/train_a3c_moa.py
+++ b/run_scripts/train_a3c_moa.py
@@ -23,7 +23,7 @@ tf.app.flags.DEFINE_integer(
     'num_agents', 5,
     'Number of agent policies')
 tf.app.flags.DEFINE_integer(
-    'num_cpus', 17,
+    'num_cpus', 8,
     'Number of available CPUs')
 tf.app.flags.DEFINE_integer(
     'num_gpus', 0,
@@ -38,7 +38,7 @@ tf.app.flags.DEFINE_float(
     'num_workers_per_device', 1,
     'Number of workers to place on a single device (CPU or GPU)')
 tf.app.flags.DEFINE_boolean(
-    'tune', True,
+    'tune', False,
     'Set to true to do hyperparameter tuning.')
 tf.app.flags.DEFINE_boolean(
     'debug', False,
@@ -178,7 +178,7 @@ def main(unused_argv):
     # else:
     #     ray.init(num_cpus=FLAGS.num_cpus, object_store_memory=int(25e10),
     #              redis_max_memory=int(50e10))
-    ray.init(redis_address="localhost:6379")
+    ray.init()
     if FLAGS.env == 'harvest':
         hparams = harvest_default_params
     else:
@@ -204,7 +204,6 @@ def main(unused_argv):
             },
             'checkpoint_freq': 100,
             "config": config,
-            'upload_dir': 's3://njaques.experiments/fourth_reproduction/a3c_causal_moa_cleanup'
         }
     }, resume=FLAGS.resume)
 

--- a/run_scripts/train_baseline.py
+++ b/run_scripts/train_baseline.py
@@ -53,12 +53,12 @@ tf.app.flags.DEFINE_float(
 harvest_default_params = {
     'lr_init': 0.00136,
     'lr_final': 0.000028,
-    'entropy_coeff': -.000687}
+    'entropy_coeff': .000687}
 
 cleanup_default_params = {
     'lr_init': 0.00126,
     'lr_final': 0.000012,
-    'entropy_coeff': -.00176}
+    'entropy_coeff': .00176}
 
 
 def setup(env, hparams, algorithm, train_batch_size, num_cpus, num_gpus,

--- a/run_scripts/train_baseline_a3c.py
+++ b/run_scripts/train_baseline_a3c.py
@@ -127,7 +127,7 @@ def setup(env, hparams, num_cpus, num_gpus, num_agents, use_gpus_for_workers=Fal
             "num_cpus_for_driver": cpus_for_driver,
             "num_gpus_per_worker": num_gpus_per_worker,   # Can be a fraction
             "num_cpus_per_worker": num_cpus_per_worker,   # Can be a fraction
-            "entropy_coeff": tune.grid_search([0, -1e-1, -1e-2]),
+            "entropy_coeff": tune.grid_search([0, 1e-1, 1e-2]),
             "multiagent": {
                 "policy_graphs": policy_graphs,
                 "policy_mapping_fn": tune.function(policy_mapping_fn),

--- a/run_scripts/train_baseline_a3c_actions.py
+++ b/run_scripts/train_baseline_a3c_actions.py
@@ -132,7 +132,7 @@ def setup(env, hparams, num_cpus, num_gpus, num_agents, use_gpus_for_workers=Fal
             "num_cpus_for_driver": cpus_for_driver,
             "num_gpus_per_worker": num_gpus_per_worker,  # Can be a fraction
             "num_cpus_per_worker": num_cpus_per_worker,  # Can be a fraction
-            "entropy_coeff": tune.grid_search([0, -1e-1, -1e-2]),
+            "entropy_coeff": tune.grid_search([0, 1e-1, 1e-2]),
             "multiagent": {
                 "policy_graphs": policy_graphs,
                 "policy_mapping_fn": tune.function(policy_mapping_fn),


### PR DESCRIPTION
The entropy sign was inconsistent in A3C run scripts. Some were negative, others positive. This raised DepreciationWarnings with Ray versions since 0.6.5. See https://github.com/ray-project/ray/pull/4374

For the A3C/A2C/ppo/IMPALA algorithms, the entropy coefficient sign must be positive, and is internally flipped in Ray when needed.

I also suggest updating to Ray 0.6.6 as it is the latest release, with no other breaking changes.