### PR TITLE
Sample async was on, causing replay errors

### DIFF
--- a/visuallizer_rllib.py
+++ b/visuallizer_rllib.py
@@ -82,6 +82,7 @@ def visualizer_rllib(args):
     # Run on only one cpu for rendering purposes if possible; A3C requires two
     if config_run == 'A3C':
         config['num_workers'] = 1
+        config["sample_async"] = False
     else:
         config['num_workers'] = 0
 


### PR DESCRIPTION
Sample async was on in A3C, causing the env to keep sampling too many times after each step. Resolves #147 