### PR TITLE
Requirements fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gym==0.10.9
-lz4
+lz4==2.2.1
 matplotlib==3.1.1
 numpy==1.16.0
 opencv-python==4.0.0.21
@@ -16,3 +16,4 @@ scipy==1.2.0
 six==1.12.0
 termcolor==1.1.0
 urllib3==1.24.1
+wheel==0.33.6


### PR DESCRIPTION
Added wheel to requirements.txt, without it `pip install -r requirements.txt` throws errors if it is not present already.

Froze lz4 library version requirement.