### PR TITLE
Fix issue installing with dependency matplotlib 3.0.2 on macOS Mojave

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
     - pip:
         - numpy==1.16.0
         - gym==0.10.9
-        - matplotlib==3.0.2
+        - matplotlib==3.1.3
         - opencv-python
         - ray==0.6.1
         - tensorflow==1.12.0


### PR DESCRIPTION
As mentioned in https://github.com/eugenevinitsky/sequential_social_dilemma_games/issues/170