### PR TITLE
Adjusted cleanup colors for river, stream, and waste cells so that rivers appear light-grey-blue and wastes appear brown when rendered. Fixes #176 

### DIFF
--- a/social_dilemmas/envs/cleanup.py
+++ b/social_dilemmas/envs/cleanup.py
@@ -11,9 +11,9 @@ ACTIONS['CLEAN'] = 5  # length of cleanup beam
 
 # Custom colour dictionary
 CLEANUP_COLORS = {'C': [100, 255, 255],  # Cyan cleaning beam
-                  'S': [113, 75, 24],  # Light grey-blue stream cell
-                  'H': [99, 156, 194],  # brown waste cells
-                  'R': [113, 75, 24]}  # Light grey-blue river cell
+                  'S': [99, 156, 194],  # Light grey-blue stream cell
+                  'H': [113, 75, 24],  # brown waste cells
+                  'R': [99, 156, 194]}  # Light grey-blue river cell
 
 SPAWN_PROB = [0, 0.005, 0.02, 0.05]
 


### PR DESCRIPTION
When the env is rendered, river and stream cells appear brown while waste cells appear light-grey-blue. This results from the rgb color list assigned to this cells in the cleanup color dictionary
https://github.com/eugenevinitsky/sequential_social_dilemma_games/blob/9d1809f7b755f38a3a3883e41c4e72eb44bad629/social_dilemmas/envs/cleanup.py#L12-L16

The rgb list, [99, 156, 194], is light grey-blue while [113, 75, 24] is brown. The color dictionary was modified to depict the correct rgb color for light grey-blue and brown (i.e swapping the current values for light grey-blue and brown).

