### PR TITLE
Fix numpy versioning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pettingzoo>=1.12.0
 opencv-python>=3.0
 ray[rllib]==0.8.5
 tensorflow>=2.4.0
-numpy==1.19.2
+numpy>=1.19.2
 scipy
 pandas
 matplotlib


### PR DESCRIPTION
Right now requirements.txt specifies an exact version of numpy. There's no reasonable way this is necessary and causes conflicts when installing in systems